### PR TITLE
1.3 Improved Pipe & Roof Mapping

### DIFF
--- a/Contents/mods/FunctionalGutters/42/media/lua/client/FG_UI_ContextMenu.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/client/FG_UI_ContextMenu.lua
@@ -10,7 +10,8 @@ end
 
 local function AddGutterSystemPanelOption(player, context, drainObject)
     local playerObject = getSpecificPlayer(player)
-    context:addOption(getText("UI_context_menu_FunctionalGutters_GutterSubMenu"), playerObject, DoOpenGutterPanel, drainObject)
+    local option = context:addOption(getText("UI_context_menu_FunctionalGutters_GutterSubMenu"), playerObject, DoOpenGutterPanel, drainObject)
+    option.iconTexture = getTexture("media/ui/FG_Plumb_Icon.png")
 end
 
 local function AddGutterSystemContext(player, context, worldobjects, test)

--- a/Contents/mods/FunctionalGutters/42/media/lua/client/FG_UI_GutterInfoPanel.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/client/FG_UI_GutterInfoPanel.lua
@@ -27,24 +27,24 @@ function FG_UI_GutterInfoPanel:renderPipeInfo()
     local c = self.textColor
     self:renderText(getText("UI_panel_FunctionalGutters_section_Pipes_title"), x, y, c.r, c.g, c.b, c.a, UIFont.Small)
 
-    -- TODO verify check is proper
-    if not self.gutterSection or self.gutterSection.pipeMap == nil then
+    if not self.gutterSection or not self.gutterSection.pipeMap then
         return
     end
+
     local pipeMap = self.gutterSection.pipeMap
-    local drainCount = pipeMap._drain_count
+    local drainCount = pipeMap[enums.pipeType.drain].count
     if self.pipeInfo.drain.cache~=drainCount then
         self.pipeInfo.drain.cache = drainCount
         self.pipeInfo.drain.value = tostring(drainCount)
     end
 
-    local verticalCount = pipeMap._vertical_count
+    local verticalCount = pipeMap[enums.pipeType.vertical].count
     if self.pipeInfo.vertical.cache~=verticalCount then
         self.pipeInfo.vertical.cache = verticalCount
         self.pipeInfo.vertical.value = tostring(verticalCount)
     end
 
-    local gutterCount = pipeMap._gutter_count
+    local gutterCount = pipeMap[enums.pipeType.gutter].count
     if self.pipeInfo.gutter.cache~=gutterCount then
         self.pipeInfo.gutter.cache = gutterCount
         self.pipeInfo.gutter.value = tostring(gutterCount)
@@ -294,12 +294,12 @@ end
 function FG_UI_GutterInfoPanel:highlightGutterObjects(highlight)
     if not self.gutterSection.pipeMap then return end
 
-    if not self.gutterSection.pipeMap._all then
+    if not self.gutterSection.pipeMap.all then
         utils:modPrint("No gutter pipe map found for section: "..tostring(self.gutterSection))
         return
     end
 
-    for _, pipeSquare in pairs(self.gutterSection.pipeMap._all) do
+    for _, pipeSquare in pairs(self.gutterSection.pipeMap.all.squares) do
         self:highlightGutterObject(pipeSquare, highlight)
     end
 
@@ -309,7 +309,7 @@ end
 function FG_UI_GutterInfoPanel:highlightRoofArea(highlight)
     if not self.gutterSection.roofMap then return end
 
-    for _, roofSquare in pairs(self.gutterSection.roofMap) do
+    for _, roofSquare in pairs(self.gutterSection.roofMap.squares) do
         self:highlightCoveredRoof(roofSquare, highlight)
     end
     self.roofAreaHighlight = highlight
@@ -372,7 +372,10 @@ function FG_UI_GutterInfoPanel:new(x, y, width, height, gutter, gutterSection)
     o.tagColor = {r=0.8,g=0.8,b=0.8,a=1}
     o.invalidColor = {r=0.6,g=0.2,b=0.2,a=1}
 
+    ---@type IsoObject
     o.gutterDrain = gutter
+
+    ---@type GutterSection
     o.gutterSection = gutterSection
 
     o.gutterHighlight = false

--- a/Contents/mods/FunctionalGutters/42/media/lua/client/FG_UI_GutterInfoPanel.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/client/FG_UI_GutterInfoPanel.lua
@@ -27,23 +27,24 @@ function FG_UI_GutterInfoPanel:renderPipeInfo()
     local c = self.textColor
     self:renderText(getText("UI_panel_FunctionalGutters_section_Pipes_title"), x, y, c.r, c.g, c.b, c.a, UIFont.Small)
 
-    if not self.gutterSection or not self.gutterSection.pipeMap == nil then
+    -- TODO verify check is proper
+    if not self.gutterSection or self.gutterSection.pipeMap == nil then
         return
     end
     local pipeMap = self.gutterSection.pipeMap
-    local drainCount = #pipeMap[enums.pipeType.drain]
+    local drainCount = pipeMap._drain_count
     if self.pipeInfo.drain.cache~=drainCount then
         self.pipeInfo.drain.cache = drainCount
         self.pipeInfo.drain.value = tostring(drainCount)
     end
 
-    local verticalCount = #pipeMap[enums.pipeType.vertical]
+    local verticalCount = pipeMap._vertical_count
     if self.pipeInfo.vertical.cache~=verticalCount then
         self.pipeInfo.vertical.cache = verticalCount
         self.pipeInfo.vertical.value = tostring(verticalCount)
     end
 
-    local gutterCount = #pipeMap[enums.pipeType.gutter]
+    local gutterCount = pipeMap._gutter_count
     if self.pipeInfo.gutter.cache~=gutterCount then
         self.pipeInfo.gutter.cache = gutterCount
         self.pipeInfo.gutter.value = tostring(gutterCount)
@@ -293,12 +294,15 @@ end
 function FG_UI_GutterInfoPanel:highlightGutterObjects(highlight)
     if not self.gutterSection.pipeMap then return end
 
-    for _, pipeTypeSquares in pairs(self.gutterSection.pipeMap) do
-        for i=1, #pipeTypeSquares do
-            local pipeSquare = pipeTypeSquares[i]
-            self:highlightGutterObject(pipeSquare, highlight)
-        end
+    if not self.gutterSection.pipeMap._all then
+        utils:modPrint("No gutter pipe map found for section: "..tostring(self.gutterSection))
+        return
     end
+
+    for _, pipeSquare in pairs(self.gutterSection.pipeMap._all) do
+        self:highlightGutterObject(pipeSquare, highlight)
+    end
+
     self.gutterHighlight = highlight
 end
 
@@ -346,6 +350,13 @@ function FG_UI_GutterInfoPanel:reloadInfo()
     self.square = self.gutterDrain:getSquare()
 end
 
+---@param x integer
+---@param y integer
+---@param width integer
+---@param height integer
+---@param gutter IsoObject
+---@param gutterSection GutterSection
+---@return ISPanel
 function FG_UI_GutterInfoPanel:new(x, y, width, height, gutter, gutterSection)
     local o = {}
     o = ISPanel:new(x, y, width, height)

--- a/Contents/mods/FunctionalGutters/42/media/lua/client/FG_UI_GutterPanel.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/client/FG_UI_GutterPanel.lua
@@ -518,7 +518,7 @@ function FG_UI_GutterPanel:reloadInfo()
     end
 
     self.gutterSection = serviceUtils:calculateGutterSection(self.gutterSquare)
-    if not self.gutterSection then
+    if not self.gutterSection or not self.gutterSection.pipeMap then
         self:close()
         return
     end

--- a/Contents/mods/FunctionalGutters/42/media/lua/server/FG_Server_Events.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/server/FG_Server_Events.lua
@@ -45,23 +45,26 @@ function GutterServerManager.OnClientCommand(module, command, player, args)
 end
 
 local function loadTroughGlobalObject(object)
-    -- Wrap load full trough function to trigger event if trough is on a drain pipe square
-    local primaryTrough, secondaryTrough = globalObjectUtils:loadFullTrough(object)
-    if not primaryTrough then
-        return nil
-    end
+    -- TODO REDO convert secondaryTrough to list of troughs
+    return nil
 
-    local primaryTroughSquare = primaryTrough:getSquare()
-    if utils:isDrainPipeSquare(primaryTroughSquare) then
-        -- Primary trough is on drain pipe square
-        triggerEvent(enums.modEvents.OnGutterTileUpdate, primaryTroughSquare)
-    elseif secondaryTrough then
-        local secondaryTroughSquare = secondaryTrough:getSquare()
-        if utils:isDrainPipeSquare(secondaryTroughSquare) then
-            -- Secondary trough is on drain pipe square
-            triggerEvent(enums.modEvents.OnGutterTileUpdate, secondaryTroughSquare)
-        end
-    end
+    -- -- Wrap load full trough function to trigger event if trough is on a drain pipe square
+    -- local primaryTrough, secondaryTrough = globalObjectUtils:loadFullTrough(object)
+    -- if not primaryTrough then
+    --     return nil
+    -- end
+
+    -- local primaryTroughSquare = primaryTrough:getSquare()
+    -- if utils:isDrainPipeSquare(primaryTroughSquare) then
+    --     -- Primary trough is on drain pipe square
+    --     triggerEvent(enums.modEvents.OnGutterTileUpdate, primaryTroughSquare)
+    -- elseif secondaryTrough then
+    --     local secondaryTroughSquare = secondaryTrough:getSquare()
+    --     if utils:isDrainPipeSquare(secondaryTroughSquare) then
+    --         -- Secondary trough is on drain pipe square
+    --         triggerEvent(enums.modEvents.OnGutterTileUpdate, secondaryTroughSquare)
+    --     end
+    -- end
 end
 
 function GutterServerManager.OnIsoObjectBuilt(square, sprite)
@@ -95,6 +98,7 @@ function GutterServerManager.OnIsoObjectBuilt(square, sprite)
         -- Trough was built, check if it is multi-tile
         local troughObject = utils:getSpecificIsoObjectFromSquare(square, sprite)
         if troughObject then
+            -- TODO REDO
             -- TODO eventually use generic sprite grid instead of trough-specific to support other multi-tile objects
             local otherTroughObject = troughUtils:getOtherTroughObject(troughObject)
             if otherTroughObject then
@@ -300,3 +304,5 @@ Events.OnObjectAdded.Add(GutterServerManager.OnIsoObjectPlaced)
 Events.OnTileRemoved.Add(GutterServerManager.OnIsoObjectRemoved)
 
 Events.OnClientCommand.Add(GutterServerManager.OnClientCommand)
+
+-- TODO REDO generate list of trough sprites from FeedingTroughDef on game start

--- a/Contents/mods/FunctionalGutters/42/media/lua/server/FG_Service.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/server/FG_Service.lua
@@ -75,7 +75,7 @@ function gutterService:connectCollector(collectorObject)
     end
 
     local gutterSection = serviceUtils:calculateGutterSection(square)
-    if not gutterSection then
+    if not gutterSection or not gutterSection.pipeMap then
         utils:modPrint("No gutter section found for square: "..tostring(square:getX())..", "..tostring(square:getY())..", "..tostring(square:getZ()))
         return
     end

--- a/Contents/mods/FunctionalGutters/42/media/lua/server/FG_Utils_GlobalObject.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/server/FG_Utils_GlobalObject.lua
@@ -5,9 +5,6 @@ local troughUtils = require("FG_Utils_Trough")
 
 local globalObjectUtils = {}
 
--- TODO use FeedingTroughDef to clean up replaceExistingTrough
--- local localFeedingTroughDef = FeedingTroughDef
-
 ---@param square IsoGridSquare
 function globalObjectUtils:removeExistingLuaObject(square)
     local troughSystem = SFeedingTroughSystem.instance
@@ -22,38 +19,22 @@ end
 ---@return IsoFeedingTrough
 function globalObjectUtils:replaceExistingTrough(isoObject)
     utils:modPrint('Upgrading IsoObject to IsoFeedingTrough: '..tostring(isoObject))
-    local square = isoObject:getSquare()
-    local spriteName = isoObject:getSprite():getName()
-    local index = isoObject:getObjectIndex()
-    self:removeExistingLuaObject(square)
-    square:transmitRemoveItemFromSquare(isoObject)
-    local north = true;
-    if "location_farm_accesories_01_14" == spriteName or "location_farm_accesories_01_4" == spriteName or "location_farm_accesories_01_5" == spriteName or "location_farm_accesories_01_34" == spriteName or "location_farm_accesories_01_35" == spriteName then
-        north = false;
-    end
-    isoObject = IsoFeedingTrough.new(square, spriteName, nil)
-    isoObject:setNorth(north);
-    if "location_farm_accesories_01_5" == spriteName then
-        isoObject:setLinkedX(square:getX());
-        isoObject:setLinkedY(square:getY() + 1);
-    end
-    if "location_farm_accesories_01_6" == spriteName then
-        isoObject:setLinkedX(square:getX() + 1);
-        isoObject:setLinkedY(square:getY());
-    end
-    if "location_farm_accesories_01_32" == spriteName then
-        isoObject:setLinkedX(square:getX() + 1);
-        isoObject:setLinkedY(square:getY());
-    end
-    if "location_farm_accesories_01_35" == spriteName then
-        isoObject:setLinkedX(square:getX());
-        isoObject:setLinkedY(square:getY() + 1);
-    end
-    isoObject:initWithDef();
-    square:AddSpecialObject(isoObject, index)
-    isoObject:transmitCompleteItemToClients()
 
-    isoObject:checkOverlayFull();
+    local square = isoObject:getSquare()
+	local spriteName = isoObject:getSprite():getName()
+	local index = isoObject:getObjectIndex()
+    local isNorth = troughUtils:isTroughSpriteNorth(spriteName)
+
+	self:removeExistingLuaObject(square)
+
+	square:transmitRemoveItemFromSquare(isoObject)
+	isoObject = IsoFeedingTrough.new(square, spriteName, nil)
+	isoObject:setNorth(isNorth);
+	isoObject:initWithDef()
+	square:AddSpecialObject(isoObject, index)
+	isoObject:transmitCompleteItemToClients()
+	isoObject:checkOverlayFull();
+
     return isoObject
 end
 
@@ -70,6 +51,7 @@ function globalObjectUtils:loadTrough(object)
     return object
 end
 
+-- TODO REDO support any amount of secondary troughs now that triple & quad troughs exist
 ---@param troughObject IsoFeedingTrough|IsoObject
 ---@return IsoFeedingTrough|nil primaryTrough, IsoFeedingTrough|nil secondaryTrough
 function globalObjectUtils:loadFullTrough(troughObject)
@@ -79,6 +61,7 @@ function globalObjectUtils:loadFullTrough(troughObject)
     -- Ignore if this is already a global trough object
     if troughUtils:isTroughObject(troughObject) then return nil end
 
+    -- TODO REDO response won't work for non-loaded troughs
     local primaryTrough = troughUtils:getPrimaryTrough(troughObject)
     if not primaryTrough then
         -- Primary through hasn't been placed yet

--- a/Contents/mods/FunctionalGutters/42/media/lua/server/collector/FG_Collector_Trough.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/server/collector/FG_Collector_Trough.lua
@@ -15,9 +15,12 @@ end
 
 function TroughService:connectCollector(containerObject, gutterRainFactor)
     if troughUtils:isTroughSprite(containerObject:getSpriteName()) and not troughUtils:isTroughObject(containerObject) then
+        utils:modPrint("Cannot connect non-IsoFeedingTrough object")
+        return false
+        -- TODO REDO remove
         -- Trough is still an IsoObject and needs to be converted to IsoFeedingTrough with a global object
-        containerObject, _ = globalObjectUtils:loadFullTrough(containerObject)
-        if not containerObject then return false end
+        -- containerObject, _ = globalObjectUtils:loadFullTrough(containerObject)
+        -- if not containerObject then return false end
     end
 
     -- Ensure the 'primary' trough object is being used for multi-tile troughs

--- a/Contents/mods/FunctionalGutters/42/media/lua/server/pipe/FG_Pipe_Drain.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/server/pipe/FG_Pipe_Drain.lua
@@ -68,7 +68,7 @@ function DrainPipeService:onIsValid(buildParams)
     end
 
     -- Requires no existing drain pipe within x tiles (with caveat)
-    local closeDrainPipe = isoUtils:findPipeInRadius(square, 6, enums.pipeType.drain)
+    local closeDrainPipe = isoUtils:findPipeInRadius(square, 3, enums.pipeType.drain)
     if closeDrainPipe then
         -- Check if drain pipe in on the same pre-made building as the selected drain square
         -- Allows for placing drains closer together when they are part of different nearby buildings

--- a/Contents/mods/FunctionalGutters/42/media/lua/server/pipe/FG_Pipe_Drain.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/server/pipe/FG_Pipe_Drain.lua
@@ -15,7 +15,6 @@ end
 
 function DrainPipeService:onCreate(createParams)
     local object = createParams.thumpable
-    utils:modPrint("Drain pipe on create func: "..tostring(object))
     -- Bug in vanilla atm where tools that are 'drained' when building an iso thumpable object are added to the object's mod data
     -- The issue is that the consumed build inputs added to the object's mod data are also used to determine what items can be returned on scrap
     -- This leads to a weird bug in vanilla where scrapping a metal iso object can return a full blowtorch and/or welding rods

--- a/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Enums.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Enums.lua
@@ -310,6 +310,7 @@ enums.troughBaseRainFactor = 0.55
 enums.maxRoofCrawlSteps = 4
 enums.maxGutterCrawlSteps = 48
 enums.maxBuildingBoundCrawlSteps = 25
+enums.maxRoofArea = 500 -- Max roof area in tiles
 enums.defaultDrainPipeSearchRadius = 16
 enums.defaultDrainPipeSearchHeight = 1
 enums.gutterSectionPerimeterLength = 9

--- a/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Enums.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Enums.lua
@@ -204,7 +204,6 @@ local function mapPipesByPosition(position)
     return positionPipes
 end
 
--- TODO rename to pipeSpriteAtlas?
 enums.pipeAtlas = {}
 enums.pipeAtlas.type = {}
 enums.pipeAtlas.type[enums.pipeType.drain] = mapPipesByType(enums.pipeType.drain)
@@ -213,10 +212,10 @@ enums.pipeAtlas.type[enums.pipeType.horizontal] = mapPipesByType(enums.pipeType.
 enums.pipeAtlas.type[enums.pipeType.gutter] = mapPipesByType(enums.pipeType.gutter)
 
 enums.pipeAtlas.position = {}
-enums.pipeAtlas.position[IsoDirections.N] = mapPipesByPosition(IsoDirections.NW)
-enums.pipeAtlas.position[IsoDirections.S] = mapPipesByPosition(IsoDirections.SE)
-enums.pipeAtlas.position[IsoDirections.E] = mapPipesByPosition(IsoDirections.NE)
-enums.pipeAtlas.position[IsoDirections.W] = mapPipesByPosition(IsoDirections.SW)
+enums.pipeAtlas.position[IsoDirections.N] = mapPipesByPosition(IsoDirections.N)
+enums.pipeAtlas.position[IsoDirections.S] = mapPipesByPosition(IsoDirections.S)
+enums.pipeAtlas.position[IsoDirections.E] = mapPipesByPosition(IsoDirections.E)
+enums.pipeAtlas.position[IsoDirections.W] = mapPipesByPosition(IsoDirections.W)
 enums.pipeAtlas.position[IsoDirections.NW] = mapPipesByPosition(IsoDirections.NW)
 enums.pipeAtlas.position[IsoDirections.NE] = mapPipesByPosition(IsoDirections.NE)
 enums.pipeAtlas.position[IsoDirections.SW] = mapPipesByPosition(IsoDirections.SW)
@@ -314,23 +313,29 @@ enums.textures.icon = {
     collectorOff = "media/ui/FG_Collector_Icon_Off.png",
 }
 
-return enums
+---@alias PipeTypeMap 
+---|{ 
+---squares: table<string, IsoGridSquare>, 
+---count: integer, 
+---maxZ: integer }
 
 -- Map of pipe type to list of squares containing a pipe of that type for a connected gutter system
 ---@alias GutterPipeMap 
 ---|{
----[PipeType.drain]: table<string, IsoGridSquare>,
----[PipeType.vertical]: table<string, IsoGridSquare>,
----[PipeType.gutter]: table<string, IsoGridSquare>,
----["_all"]: table<string, IsoGridSquare>,
----["_count"]: integer,
----["_drain_count"]: integer,
----["_vertical_count"]: integer,
----["_gutter_count"]: integer } 
-
+---[PipeType.drain]: PipeTypeMap,
+---[PipeType.vertical]: PipeTypeMap,
+---[PipeType.gutter]: PipeTypeMap,
+---all: PipeTypeMap } 
 
 -- Map of square ID to IsoGridSquare for a connected roof system
----@alias GutterRoofMap table<string, IsoGridSquare> 
+---@alias GutterRoofMap 
+---|{ 
+---squares: table<string, IsoGridSquare>, 
+---count: integer, 
+---maxZ: integer }
+
+-- Map of object ID to IsoObject for all drains from connected or overlapping gutter systems
+---@alias AssociatedDrainMap table<string, IsoObject> 
 
 ---@alias GutterSection
 ---|{ 
@@ -342,7 +347,10 @@ return enums
 ---["pipeMap"]: GutterPipeMap|nil, 
 ---["roofMap"]: GutterRoofMap|nil, 
 ---["buildingType"]: BuildingType|nil, 
+---["drains"]: AssociatedDrainMap|nil, 
 ---["maxLevel"]: integer|nil, 
 ---["averageGutterCapacity"]: integer, 
 ---["overflowArea"]: integer, 
 ---["overflowEfficiency"]: number }
+
+return enums

--- a/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Enums.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Enums.lua
@@ -204,6 +204,7 @@ local function mapPipesByPosition(position)
     return positionPipes
 end
 
+-- TODO rename to pipeSpriteAtlas?
 enums.pipeAtlas = {}
 enums.pipeAtlas.type = {}
 enums.pipeAtlas.type[enums.pipeType.drain] = mapPipesByType(enums.pipeType.drain)
@@ -221,33 +222,12 @@ enums.pipeAtlas.position[IsoDirections.NE] = mapPipesByPosition(IsoDirections.NE
 enums.pipeAtlas.position[IsoDirections.SW] = mapPipesByPosition(IsoDirections.SW)
 enums.pipeAtlas.position[IsoDirections.SE] = mapPipesByPosition(IsoDirections.SE)
 
--- TODO REDO
--- TODO auto source from FeedingTroughDef?
--- NOTE: 'accessories' is misspelled in sprite names
+-- NOTE: filled using vanilla trough definitions after init event
 enums.troughSprites = table.newarray()
--- enums.troughSprites = table.newarray(
---     "location_farm_accesories_01_4", -- Wood Double West
---     "location_farm_accesories_01_5", -- Wood Double West
---     "location_farm_accesories_01_6", -- Wood Double North
---     "location_farm_accesories_01_7", -- Wood Double North
---     "location_farm_accesories_01_14", -- Wood Single West
---     "location_farm_accesories_01_15", -- Wood Single North
---     "location_farm_accesories_01_34", -- Metal Double West
---     "location_farm_accesories_01_35", -- Metal Double West
---     "location_farm_accesories_01_32", -- Metal Double North
---     "location_farm_accesories_01_33" -- Metal Double North
--- )
-
 enums.smallTroughSprites = table.newarray()
--- enums.smallTroughSprites = table.newarray(
---     "location_farm_accesories_01_14", -- Wood Single West
---     "location_farm_accesories_01_15" -- Wood Single North
--- )
-
 enums.primaryTroughSprites = table.newarray()
 enums.northTroughSprites = table.newarray()
 
--- TODO do we need getters since these aren't local variables?
 function enums:getTroughSprites()
     return self.troughSprites
 end
@@ -351,6 +331,7 @@ return enums
 
 -- Map of square ID to IsoGridSquare for a connected roof system
 ---@alias GutterRoofMap table<string, IsoGridSquare> 
+
 ---@alias GutterSection
 ---|{ 
 ---["roofArea"]: integer, 

--- a/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Enums.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Enums.lua
@@ -3,6 +3,7 @@ local enums = {}
 enums.modName = "FunctionalGutters"
 enums.modDisplayName = "Functional Gutters"
 
+---@enum PipeType
 enums.pipeType = {
     drain = "drain",
     vertical = "vertical",
@@ -10,11 +11,13 @@ enums.pipeType = {
     gutter = "gutter",
 }
 
+---@enum CollectorType
 enums.collectorType = {
     fluidContainer = "fluidContainer",
     trough = "trough",
 }
 
+---@enum BuildingType
 enums.buildingType = {
     vanilla = "vanilla",
     custom = "custom",
@@ -218,25 +221,48 @@ enums.pipeAtlas.position[IsoDirections.NE] = mapPipesByPosition(IsoDirections.NE
 enums.pipeAtlas.position[IsoDirections.SW] = mapPipesByPosition(IsoDirections.SW)
 enums.pipeAtlas.position[IsoDirections.SE] = mapPipesByPosition(IsoDirections.SE)
 
+-- TODO REDO
 -- TODO auto source from FeedingTroughDef?
 -- NOTE: 'accessories' is misspelled in sprite names
-enums.troughSprites = table.newarray(
-    "location_farm_accesories_01_4", -- Wood Double West
-    "location_farm_accesories_01_5", -- Wood Double West
-    "location_farm_accesories_01_6", -- Wood Double North
-    "location_farm_accesories_01_7", -- Wood Double North
-    "location_farm_accesories_01_14", -- Wood Single West
-    "location_farm_accesories_01_15", -- Wood Single North
-    "location_farm_accesories_01_34", -- Metal Double West
-    "location_farm_accesories_01_35", -- Metal Double West
-    "location_farm_accesories_01_32", -- Metal Double North
-    "location_farm_accesories_01_33" -- Metal Double North
-)
+enums.troughSprites = table.newarray()
+-- enums.troughSprites = table.newarray(
+--     "location_farm_accesories_01_4", -- Wood Double West
+--     "location_farm_accesories_01_5", -- Wood Double West
+--     "location_farm_accesories_01_6", -- Wood Double North
+--     "location_farm_accesories_01_7", -- Wood Double North
+--     "location_farm_accesories_01_14", -- Wood Single West
+--     "location_farm_accesories_01_15", -- Wood Single North
+--     "location_farm_accesories_01_34", -- Metal Double West
+--     "location_farm_accesories_01_35", -- Metal Double West
+--     "location_farm_accesories_01_32", -- Metal Double North
+--     "location_farm_accesories_01_33" -- Metal Double North
+-- )
 
-enums.smallTroughSprites = table.newarray(
-    "location_farm_accesories_01_14", -- Wood Single West
-    "location_farm_accesories_01_15" -- Wood Single North
-)
+enums.smallTroughSprites = table.newarray()
+-- enums.smallTroughSprites = table.newarray(
+--     "location_farm_accesories_01_14", -- Wood Single West
+--     "location_farm_accesories_01_15" -- Wood Single North
+-- )
+
+enums.primaryTroughSprites = table.newarray()
+enums.northTroughSprites = table.newarray()
+
+-- TODO do we need getters since these aren't local variables?
+function enums:getTroughSprites()
+    return self.troughSprites
+end
+
+function enums:getSmallTroughSprites()
+    return self.smallTroughSprites
+end
+
+function enums:getPrimaryTroughSprites()
+    return self.troughSprites
+end
+
+function enums:getNorthTroughSprites()
+    return self.northTroughSprites
+end
 
 enums.woodenPoleSprite = "walls_exterior_wooden_01_27"
 
@@ -282,7 +308,7 @@ enums.modEvents = {
 
 enums.troughBaseRainFactor = 0.55
 enums.maxRoofCrawlSteps = 4
-enums.maxGutterCrawlSteps = 36
+enums.maxGutterCrawlSteps = 48
 enums.maxBuildingBoundCrawlSteps = 25
 enums.defaultDrainPipeSearchRadius = 16
 enums.defaultDrainPipeSearchHeight = 1
@@ -308,3 +334,33 @@ enums.textures.icon = {
 }
 
 return enums
+
+-- Map of pipe type to list of squares containing a pipe of that type for a connected gutter system
+---@alias GutterPipeMap 
+---|{
+---[PipeType.drain]: table<string, IsoGridSquare>,
+---[PipeType.vertical]: table<string, IsoGridSquare>,
+---[PipeType.gutter]: table<string, IsoGridSquare>,
+---["_all"]: table<string, IsoGridSquare>,
+---["_count"]: integer,
+---["_drain_count"]: integer,
+---["_vertical_count"]: integer,
+---["_gutter_count"]: integer } 
+
+
+-- Map of square ID to IsoGridSquare for a connected roof system
+---@alias GutterRoofMap table<string, IsoGridSquare> 
+---@alias GutterSection
+---|{ 
+---["roofArea"]: integer, 
+---["tileCount"]: integer, 
+---["optimalDrainCount"]: integer, 
+---["drainCount"]: integer, 
+---["rainFactor"]: number, 
+---["pipeMap"]: GutterPipeMap|nil, 
+---["roofMap"]: GutterRoofMap|nil, 
+---["buildingType"]: BuildingType|nil, 
+---["maxLevel"]: integer|nil, 
+---["averageGutterCapacity"]: integer, 
+---["overflowArea"]: integer, 
+---["overflowEfficiency"]: number }

--- a/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils.lua
@@ -450,7 +450,7 @@ function utils:parseObjectCommandArgs(args)
     return nil
 end
 
----@param dict table<any, any>
+---@param dict {[any]: any}
 ---@return integer
 function utils:getDictSize(dict)
     local count = 0

--- a/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils.lua
@@ -450,6 +450,16 @@ function utils:parseObjectCommandArgs(args)
     return nil
 end
 
+---@param dict table<any, any>
+---@return integer
+function utils:getDictSize(dict)
+    local count = 0
+    for _ in pairs(dict) do
+        count = count + 1
+    end
+    return count
+end
+
 local function checkDebugMode()
     debugMode = options:getDebug()
 end

--- a/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Iso.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Iso.lua
@@ -6,6 +6,7 @@ local isoUtils = {}
 local localIsoDirections = IsoDirections
 local localIsoFlagType = IsoFlagType
 local table_insert = table.insert
+local table_contains = luautils.tableContains
 
 
 ---@param square IsoGridSquare
@@ -229,150 +230,231 @@ function isoUtils:getBuildingFloorArea(buildingDef, z)
     return area
 end
 
+-- TODO remove after validating new crawlGutterSquare function
+-- ---@param square IsoGridSquare
+-- ---@param squareProps PropertyContainer
+-- ---@param gutterPipeMap GutterPipeMap
+-- ---@param prevDir IsoDirections|nil
+-- ---@param crawlSteps integer|nil
+-- ---@return IsoGridSquare|nil
+-- function isoUtils:crawlHorizontalPipes(square, squareProps, gutterPipeMap, prevDir, crawlSteps)
+--     if not square then return nil end
+
+--     local hasGutterPipe = utils:isGutterPipeSquare(square, squareProps)
+--     if not hasGutterPipe then
+--         return nil
+--     end
+
+--     if not crawlSteps then crawlSteps = 0 end
+--     crawlSteps = crawlSteps + 1
+--     if crawlSteps > enums.maxGutterCrawlSteps then
+--         -- Shouldn't hit unless player builds a large system with more gutter objects
+--         -- adding as failsafe against runaway recursion which also shouldn't occur but just in case
+--         utils:modPrint("Crawl steps exceeded maximum: "..tostring(enums.maxGutterCrawlSteps))
+--         return square
+--     end
+
+--     -- Try following gutter pipes north, south, east, west
+--     local _, squareGutter, spriteName, _ = utils:getSpriteCategoryMemberOnTile(square, enums.pipeType.gutter)
+--     if squareGutter then
+--         local squareID = square:getID()
+--         gutterPipeMap[enums.pipeType.gutter][squareID] = square
+--         gutterPipeMap._all[squareID] = square
+--         gutterPipeMap._gutter_count = gutterPipeMap._gutter_count + 1 -- NOTE: bit hacky but useful to not have to dynamically check the size of the dictionary in ui
+
+--         local spriteDef = enums.pipes[spriteName]
+--         if spriteDef.position == localIsoDirections.N or spriteDef.position == localIsoDirections.NW then
+--             -- Check west
+--             if prevDir ~= localIsoDirections.E then
+--                 local westSquare = getCell():getGridSquare(square:getX() - 1, square:getY(), square:getZ())
+--                 self:crawlGutterSquare(westSquare, gutterPipeMap, localIsoDirections.W, crawlSteps)
+--             end
+
+--             -- Check east
+--             if prevDir ~= localIsoDirections.W then
+--                 local eastSquare = getCell():getGridSquare(square:getX() + 1, square:getY(), square:getZ())
+--                 self:crawlGutterSquare(eastSquare, gutterPipeMap, localIsoDirections.E, crawlSteps)
+--             end
+--         end
+
+--         if spriteDef.position == localIsoDirections.W or spriteDef.position == localIsoDirections.NW then
+--             -- Check north
+--             if prevDir ~= localIsoDirections.S then
+--                 local northSquare = getCell():getGridSquare(square:getX(), square:getY() - 1, square:getZ())
+--                 self:crawlGutterSquare(northSquare, gutterPipeMap, localIsoDirections.N, crawlSteps)
+--             end
+
+--             -- Check south
+--             if prevDir ~= localIsoDirections.N then
+--                 local southSquare = getCell():getGridSquare(square:getX(), square:getY() + 1, square:getZ())
+--                 self:crawlGutterSquare(southSquare, gutterPipeMap, localIsoDirections.S, crawlSteps)
+--             end
+--         end
+--     end
+
+--     -- TODO rethink response now that we check forked paths and won't have a singular final square
+--     return square
+-- end
+
+-- TODO remove after validating new crawlGutterSquare function
+-- ---@param square IsoGridSquare
+-- ---@param squareProps PropertyContainer
+-- ---@param gutterPipeMap GutterPipeMap
+-- ---@param prevDir IsoDirections|nil
+-- ---@param crawlSteps integer|nil
+-- ---@return IsoGridSquare|nil
+-- function isoUtils:crawlVerticalPipes(square, squareProps, gutterPipeMap, prevDir, crawlSteps)
+--     if not square then return nil end
+
+--     local hasDrainPipe = utils:isDrainPipeSquare(square, squareProps)
+--     local hasVerticalPipe = utils:isVerticalPipeSquare(square, squareProps)
+--     if not hasVerticalPipe and not hasDrainPipe then
+--         return nil
+--     end
+
+--     if not crawlSteps then crawlSteps = 0 end
+--     crawlSteps = crawlSteps + 1
+--     if crawlSteps > enums.maxGutterCrawlSteps then
+--         -- Shouldn't hit unless player builds a large system with more gutter objects
+--         -- adding as failsafe against runaway recursion which also shouldn't occur but just in case
+--         utils:modPrint("Crawl steps exceeded "..tostring(enums.maxGutterCrawlSteps))
+--         return square
+--     end
+
+--     local squareID = square:getID()
+--     if hasDrainPipe then
+--         gutterPipeMap[enums.pipeType.drain][squareID] = square
+--         gutterPipeMap._drain_count = gutterPipeMap._drain_count + 1 -- NOTE: bit hacky but useful to not have to dynamically check the size of the dictionary in ui
+--     end
+--     if hasVerticalPipe then
+--         gutterPipeMap[enums.pipeType.vertical][squareID] = square
+--         gutterPipeMap._vertical_count = gutterPipeMap._vertical_count + 1 -- NOTE: bit hacky but useful to not have to dynamically check the size of the dictionary in ui
+--     end
+
+--     gutterPipeMap._all[squareID] = square
+
+--     -- Following vertical pipes up z levels
+--     local nextSquare = getCell():getGridSquare(square:getX(), square:getY(), square:getZ() + 1)
+--     local crawlUp = self:crawlGutterSquare(nextSquare, gutterPipeMap, nil, crawlSteps) -- TODO up dir?
+--     if crawlUp then
+--         return crawlUp
+--     end
+
+--     -- TODO rethink response now that we check forked paths and won't have a singular final square
+--     return square
+-- end
+
+-- TODO remove after validating new crawlGutterSquare function
+-- ---@param square IsoGridSquare
+-- ---@param gutterPipeMap GutterPipeMap
+-- ---@param prevDir IsoDirections|nil
+-- ---@param crawlSteps integer|nil
+-- ---@return IsoGridSquare|nil
+-- function isoUtils:crawlGutterSquare(square, gutterPipeMap, prevDir, crawlSteps)
+--     if not square then return nil end
+
+--     local squareProps = square:getProperties()
+--     if not utils:isAnyPipeSquare(square, squareProps) then
+--         return nil
+--     elseif not prevDir and not utils:isVerticalPipeSquare(square, squareProps) and not utils:isDrainPipeSquare(square, squareProps) then
+--         -- When no prevDir (coming up from below), ensure a vertical pipe exists before crawling
+--         -- This is to prevent horizontal/gutter pipes from being included when there is no vertical pipe to connect them
+--         -- TODO provide "up"/"down" prevDir if we want to reverse crawl and navigate top-down
+--         return nil
+--     end
+
+--     if not crawlSteps then crawlSteps = 0 end
+--     crawlSteps = crawlSteps + 1
+--     if crawlSteps > enums.maxGutterCrawlSteps then
+--         -- Shouldn't hit unless player builds a large system with more gutter objects
+--         -- adding as failsafe against runaway recursion which also shouldn't occur but just in case
+--         utils:modPrint("Crawl steps exceeded "..tostring(enums.maxGutterCrawlSteps))
+--         return square
+--     end
+
+--     self:crawlHorizontalPipes(square, squareProps, gutterPipeMap, prevDir, crawlSteps)
+--     self:crawlVerticalPipes(square, squareProps, gutterPipeMap, prevDir, crawlSteps)
+
+--     -- TODO rethink response now that we check forked paths and won't have a singular final square
+--     return square
+-- end
+
 ---@param square IsoGridSquare
----@param squareProps PropertyContainer
----@param gutterPipeMap GutterPipeMap
----@param prevDir IsoDirections|nil
----@param crawlSteps integer|nil
----@return IsoGridSquare|nil
-function isoUtils:crawlHorizontalPipes(square, squareProps, gutterPipeMap, prevDir, crawlSteps)
-    if not square then return nil end
+---@param pipeMap GutterPipeMap
+---@return table<string, IsoGridSquare>|nil
+function isoUtils:crawlGutterSquare(square, pipeMap)
+    local squareProps = square:getProperties()
 
     local hasGutterPipe = utils:isGutterPipeSquare(square, squareProps)
-    if not hasGutterPipe then
-        return nil
-    end
-
-    if not crawlSteps then crawlSteps = 0 end
-    crawlSteps = crawlSteps + 1
-    if crawlSteps > enums.maxGutterCrawlSteps then
-        -- Shouldn't hit unless player builds a large system with more gutter objects
-        -- adding as failsafe against runaway recursion which also shouldn't occur but just in case
-        utils:modPrint("Crawl steps exceeded maximum: "..tostring(enums.maxGutterCrawlSteps))
-        return square
-    end
-
-    -- Try following gutter pipes north, south, east, west
-    local _, squareGutter, spriteName, _ = utils:getSpriteCategoryMemberOnTile(square, enums.pipeType.gutter)
-    if squareGutter then
-        local squareID = square:getID()
-        gutterPipeMap[enums.pipeType.gutter][squareID] = square
-        gutterPipeMap._all[squareID] = square
-        gutterPipeMap._gutter_count = gutterPipeMap._gutter_count + 1 -- NOTE: bit hacky but useful to not have to dynamically check the size of the dictionary in ui
-
-        local spriteDef = enums.pipes[spriteName]
-        if spriteDef.position == localIsoDirections.N or spriteDef.position == localIsoDirections.NW then
-            -- Check west
-            if prevDir ~= localIsoDirections.E then
-                local westSquare = getCell():getGridSquare(square:getX() - 1, square:getY(), square:getZ())
-                self:crawlGutterSquare(westSquare, gutterPipeMap, localIsoDirections.W, crawlSteps)
-            end
-
-            -- Check east
-            if prevDir ~= localIsoDirections.W then
-                local eastSquare = getCell():getGridSquare(square:getX() + 1, square:getY(), square:getZ())
-                self:crawlGutterSquare(eastSquare, gutterPipeMap, localIsoDirections.E, crawlSteps)
-            end
-        end
-
-        if spriteDef.position == localIsoDirections.W or spriteDef.position == localIsoDirections.NW then
-            -- Check north
-            if prevDir ~= localIsoDirections.S then
-                local northSquare = getCell():getGridSquare(square:getX(), square:getY() - 1, square:getZ())
-                self:crawlGutterSquare(northSquare, gutterPipeMap, localIsoDirections.N, crawlSteps)
-            end
-
-            -- Check south
-            if prevDir ~= localIsoDirections.N then
-                local southSquare = getCell():getGridSquare(square:getX(), square:getY() + 1, square:getZ())
-                self:crawlGutterSquare(southSquare, gutterPipeMap, localIsoDirections.S, crawlSteps)
-            end
-        end
-    end
-
-    -- TODO rethink response now that we check forked paths and won't have a singular final square
-    return square
-end
-
----@param square IsoGridSquare
----@param squareProps PropertyContainer
----@param gutterPipeMap GutterPipeMap
----@param prevDir IsoDirections|nil
----@param crawlSteps integer|nil
----@return IsoGridSquare|nil
-function isoUtils:crawlVerticalPipes(square, squareProps, gutterPipeMap, prevDir, crawlSteps)
-    if not square then return nil end
-
-    local hasDrainPipe = utils:isDrainPipeSquare(square, squareProps)
     local hasVerticalPipe = utils:isVerticalPipeSquare(square, squareProps)
-    if not hasVerticalPipe and not hasDrainPipe then
+    local hasDrainPipe = utils:isDrainPipeSquare(square, squareProps)
+    -- local hasHorizontalPipe = utils:isHorizontalPipeSquare(square, squareProps) -- NOTE: horizontal pipes don't currently exist beyond gutters
+
+    if not hasGutterPipe and not hasVerticalPipe and not hasDrainPipe then
         return nil
     end
 
-    if not crawlSteps then crawlSteps = 0 end
-    crawlSteps = crawlSteps + 1
-    if crawlSteps > enums.maxGutterCrawlSteps then
-        -- Shouldn't hit unless player builds a large system with more gutter objects
-        -- adding as failsafe against runaway recursion which also shouldn't occur but just in case
-        utils:modPrint("Crawl steps exceeded "..tostring(enums.maxGutterCrawlSteps))
-        return square
-    end
-
+    ---@type table<string, IsoGridSquare>
+    local neighborSquares = {}
     local squareID = square:getID()
+    local rootCell = square:getCell()
+    local rootX, rootY, rootZ = square:getX(), square:getY(), square:getZ()
+
     if hasDrainPipe then
-        gutterPipeMap[enums.pipeType.drain][squareID] = square
-        gutterPipeMap._drain_count = gutterPipeMap._drain_count + 1 -- NOTE: bit hacky but useful to not have to dynamically check the size of the dictionary in ui
+        -- Record in drain pipe map
+        pipeMap[enums.pipeType.drain][squareID] = square
+
+        -- Drain pipes only connect to other pipes above
+        local topSquare = rootCell:getGridSquare(rootX, rootY, rootZ + 1)
+        if topSquare then
+            neighborSquares[topSquare:getID()] = topSquare
+        end
     end
+
     if hasVerticalPipe then
-        gutterPipeMap[enums.pipeType.vertical][squareID] = square
-        gutterPipeMap._vertical_count = gutterPipeMap._vertical_count + 1 -- NOTE: bit hacky but useful to not have to dynamically check the size of the dictionary in ui
+        -- Record in vertical pipe map
+        pipeMap[enums.pipeType.vertical][squareID] = square
+
+        -- Vertical pipes only connect to other pipes above and below
+        local topSquare = rootCell:getGridSquare(rootX, rootY, rootZ + 1)
+        if topSquare then
+            neighborSquares[topSquare:getID()] = topSquare
+        end
+
+        local bottomSquare = rootCell:getGridSquare(rootX, rootY, rootZ - 1)
+        if bottomSquare then
+            neighborSquares[bottomSquare:getID()] = bottomSquare
+        end
     end
 
-    gutterPipeMap._all[squareID] = square
+    if hasGutterPipe then
+        -- Record in gutter pipe map
+        pipeMap[enums.pipeType.gutter][squareID] = square
 
-    -- Following vertical pipes up z levels
-    local nextSquare = getCell():getGridSquare(square:getX(), square:getY(), square:getZ() + 1)
-    local crawlUp = self:crawlGutterSquare(nextSquare, gutterPipeMap, nil, crawlSteps) -- TODO up dir?
-    if crawlUp then
-        return crawlUp
+        -- Gutter pipes connect to other pipes in the same z level 
+        -- TODO verify above once we allow gutters to connect/support vertical pipes on next z level
+        local northSquare = rootCell:getGridSquare(rootX, rootY - 1, rootZ)
+        if northSquare then
+            neighborSquares[northSquare:getID()] = northSquare
+        end
+
+        local southSquare = rootCell:getGridSquare(rootX, rootY + 1, rootZ)
+        if southSquare then
+            neighborSquares[southSquare:getID()] = southSquare
+        end
+
+        local eastSquare = rootCell:getGridSquare(rootX + 1, rootY, rootZ)
+        if eastSquare then
+            neighborSquares[eastSquare:getID()] = eastSquare
+        end
+
+        local westSquare = rootCell:getGridSquare(rootX - 1, rootY, rootZ)
+        if westSquare then
+            neighborSquares[westSquare:getID()] = westSquare
+        end
     end
 
-    -- TODO rethink response now that we check forked paths and won't have a singular final square
-    return square
-end
-
----@param square IsoGridSquare
----@param gutterPipeMap GutterPipeMap
----@param prevDir IsoDirections|nil
----@param crawlSteps integer|nil
----@return IsoGridSquare|nil
-function isoUtils:crawlGutterSquare(square, gutterPipeMap, prevDir, crawlSteps)
-    if not square then return nil end
-
-    local squareProps = square:getProperties()
-    if not utils:isAnyPipeSquare(square, squareProps) then
-        return nil
-    elseif not prevDir and not utils:isVerticalPipeSquare(square, squareProps) and not utils:isDrainPipeSquare(square, squareProps) then
-        -- When no prevDir (coming up from below), ensure a vertical pipe exists before crawling
-        -- This is to prevent horizontal/gutter pipes from being included when there is no vertical pipe to connect them
-        -- TODO provide "up"/"down" prevDir if we want to reverse crawl and navigate top-down
-        return nil
-    end
-
-    if not crawlSteps then crawlSteps = 0 end
-    crawlSteps = crawlSteps + 1
-    if crawlSteps > enums.maxGutterCrawlSteps then
-        -- Shouldn't hit unless player builds a large system with more gutter objects
-        -- adding as failsafe against runaway recursion which also shouldn't occur but just in case
-        utils:modPrint("Crawl steps exceeded "..tostring(enums.maxGutterCrawlSteps))
-        return square
-    end
-
-    self:crawlHorizontalPipes(square, squareProps, gutterPipeMap, prevDir, crawlSteps)
-    self:crawlVerticalPipes(square, squareProps, gutterPipeMap, prevDir, crawlSteps)
-
-    -- TODO rethink response now that we check forked paths and won't have a singular final square
-    return square
+    return neighborSquares
 end
 
 ---@param square IsoGridSquare
@@ -424,10 +506,32 @@ function isoUtils:crawlPlayerBuildingRoofSquare(square, roofMap, dir, crawlSteps
     return square
 end
 
--- TODO rename to crawlGutterPipes so that "system" can be used for the entire gutter system including roofs and meta data
----@param square IsoGridSquare
+-- TODO remove after validating new crawlGutterPipes flood fill crawler
+-- ---@param square IsoGridSquare
+-- ---@return GutterPipeMap gutterPipeMap
+-- function isoUtils:crawlGutterSystem(square)
+--     ---@type GutterPipeMap
+--     local gutterPipeMap = {
+--         [enums.pipeType.drain] = {},
+--         [enums.pipeType.vertical] = {},
+--         [enums.pipeType.gutter] = {},
+--         _all = {}, -- All squares that are part of the gutter system
+--         _count = 0, -- Total count of squares in the gutter system
+--         _drain_count = 0, -- Count of drain squares
+--         _vertical_count = 0, -- Count of vertical squares
+--         _gutter_count = 0, -- Count of gutter squares
+--     }
+--     local crawlSteps = 0
+--     self:crawlGutterSquare(square, gutterPipeMap, nil, crawlSteps)
+
+--     gutterPipeMap._count = utils:getDictSize(gutterPipeMap._all)
+
+--     return gutterPipeMap
+-- end
+
+---@param startSquare IsoGridSquare
 ---@return GutterPipeMap gutterPipeMap
-function isoUtils:crawlGutterSystem(square)
+function isoUtils:crawlGutterPipes(startSquare)
     ---@type GutterPipeMap
     local gutterPipeMap = {
         [enums.pipeType.drain] = {},
@@ -440,9 +544,48 @@ function isoUtils:crawlGutterSystem(square)
         _gutter_count = 0, -- Count of gutter squares
     }
     local crawlSteps = 0
-    self:crawlGutterSquare(square, gutterPipeMap, nil, crawlSteps)
+    local visited = {}
+    local queue = {startSquare}
 
+    -- NOTE: deep nesting if because no 'continue' in lua 5.2
+    while #queue > 0 do
+        local square = table.remove(queue, 1)
+        if square then
+            local squareID = square:getID()
+            if not visited[squareID] then
+                -- Mark square as visited
+                visited[squareID] = true
+
+                -- NOTE: crawl fn returns nil if square doesn't have any pipes
+                local nextSquares = self:crawlGutterSquare(square, gutterPipeMap)
+                if nextSquares ~= nil then
+                    -- Update meta
+                    crawlSteps = crawlSteps + 1
+                    gutterPipeMap._all[squareID] = square
+
+                    -- Add the next squares to the queue if they haven't been visited yet and don't already exist in the queue
+                    for _, nextSquare in pairs(nextSquares) do
+                        if not visited[nextSquare:getID()] and not table_contains(queue, nextSquare) then
+                            table_insert(queue, nextSquare)
+                        end
+                    end
+                end
+            end
+        end
+
+        if crawlSteps > enums.maxGutterCrawlSteps then
+            -- Shouldn't hit unless player builds a large system with more gutter objects
+            -- adding as failsafe against runaway recursion which also shouldn't occur but just in case
+            utils:modPrint("Crawl steps exceeded maximum: "..tostring(enums.maxGutterCrawlSteps))
+            break
+        end
+    end
+
+    -- Calculate metadata now that we have all the squares
     gutterPipeMap._count = utils:getDictSize(gutterPipeMap._all)
+    gutterPipeMap._drain_count = utils:getDictSize(gutterPipeMap[enums.pipeType.drain]) -- Ignore type hint warning
+    gutterPipeMap._vertical_count = utils:getDictSize(gutterPipeMap[enums.pipeType.vertical]) -- Ignore type hint warning
+    gutterPipeMap._gutter_count = utils:getDictSize(gutterPipeMap[enums.pipeType.gutter]) -- Ignore type hint warning
 
     return gutterPipeMap
 end

--- a/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Iso.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Iso.lua
@@ -182,9 +182,11 @@ function isoUtils:getAdjacentBuilding(square, directions)
 
     for i=1, #directions do
         local adjacentSquare = square:getAdjacentSquare(directions[i])
-        local adjacentBuilding = adjacentSquare:getBuilding()
-        if adjacentBuilding then
-            return adjacentBuilding
+        if adjacentSquare then
+            local adjacentBuilding = adjacentSquare:getBuilding()
+            if adjacentBuilding then
+                return adjacentBuilding
+            end
         end
     end
 

--- a/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Iso.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Iso.lua
@@ -6,8 +6,6 @@ local isoUtils = {}
 local localIsoDirections = IsoDirections
 local localIsoFlagType = IsoFlagType
 local table_insert = table.insert
-local table_contains = luautils.tableContains
-
 
 ---@param square IsoGridSquare
 ---@param north boolean
@@ -230,155 +228,6 @@ function isoUtils:getBuildingFloorArea(buildingDef, z)
     return area
 end
 
--- TODO remove after validating new crawlGutterSquare function
--- ---@param square IsoGridSquare
--- ---@param squareProps PropertyContainer
--- ---@param gutterPipeMap GutterPipeMap
--- ---@param prevDir IsoDirections|nil
--- ---@param crawlSteps integer|nil
--- ---@return IsoGridSquare|nil
--- function isoUtils:crawlHorizontalPipes(square, squareProps, gutterPipeMap, prevDir, crawlSteps)
---     if not square then return nil end
-
---     local hasGutterPipe = utils:isGutterPipeSquare(square, squareProps)
---     if not hasGutterPipe then
---         return nil
---     end
-
---     if not crawlSteps then crawlSteps = 0 end
---     crawlSteps = crawlSteps + 1
---     if crawlSteps > enums.maxGutterCrawlSteps then
---         -- Shouldn't hit unless player builds a large system with more gutter objects
---         -- adding as failsafe against runaway recursion which also shouldn't occur but just in case
---         utils:modPrint("Crawl steps exceeded maximum: "..tostring(enums.maxGutterCrawlSteps))
---         return square
---     end
-
---     -- Try following gutter pipes north, south, east, west
---     local _, squareGutter, spriteName, _ = utils:getSpriteCategoryMemberOnTile(square, enums.pipeType.gutter)
---     if squareGutter then
---         local squareID = square:getID()
---         gutterPipeMap[enums.pipeType.gutter][squareID] = square
---         gutterPipeMap._all[squareID] = square
---         gutterPipeMap._gutter_count = gutterPipeMap._gutter_count + 1 -- NOTE: bit hacky but useful to not have to dynamically check the size of the dictionary in ui
-
---         local spriteDef = enums.pipes[spriteName]
---         if spriteDef.position == localIsoDirections.N or spriteDef.position == localIsoDirections.NW then
---             -- Check west
---             if prevDir ~= localIsoDirections.E then
---                 local westSquare = getCell():getGridSquare(square:getX() - 1, square:getY(), square:getZ())
---                 self:crawlGutterSquare(westSquare, gutterPipeMap, localIsoDirections.W, crawlSteps)
---             end
-
---             -- Check east
---             if prevDir ~= localIsoDirections.W then
---                 local eastSquare = getCell():getGridSquare(square:getX() + 1, square:getY(), square:getZ())
---                 self:crawlGutterSquare(eastSquare, gutterPipeMap, localIsoDirections.E, crawlSteps)
---             end
---         end
-
---         if spriteDef.position == localIsoDirections.W or spriteDef.position == localIsoDirections.NW then
---             -- Check north
---             if prevDir ~= localIsoDirections.S then
---                 local northSquare = getCell():getGridSquare(square:getX(), square:getY() - 1, square:getZ())
---                 self:crawlGutterSquare(northSquare, gutterPipeMap, localIsoDirections.N, crawlSteps)
---             end
-
---             -- Check south
---             if prevDir ~= localIsoDirections.N then
---                 local southSquare = getCell():getGridSquare(square:getX(), square:getY() + 1, square:getZ())
---                 self:crawlGutterSquare(southSquare, gutterPipeMap, localIsoDirections.S, crawlSteps)
---             end
---         end
---     end
-
---     -- TODO rethink response now that we check forked paths and won't have a singular final square
---     return square
--- end
-
--- TODO remove after validating new crawlGutterSquare function
--- ---@param square IsoGridSquare
--- ---@param squareProps PropertyContainer
--- ---@param gutterPipeMap GutterPipeMap
--- ---@param prevDir IsoDirections|nil
--- ---@param crawlSteps integer|nil
--- ---@return IsoGridSquare|nil
--- function isoUtils:crawlVerticalPipes(square, squareProps, gutterPipeMap, prevDir, crawlSteps)
---     if not square then return nil end
-
---     local hasDrainPipe = utils:isDrainPipeSquare(square, squareProps)
---     local hasVerticalPipe = utils:isVerticalPipeSquare(square, squareProps)
---     if not hasVerticalPipe and not hasDrainPipe then
---         return nil
---     end
-
---     if not crawlSteps then crawlSteps = 0 end
---     crawlSteps = crawlSteps + 1
---     if crawlSteps > enums.maxGutterCrawlSteps then
---         -- Shouldn't hit unless player builds a large system with more gutter objects
---         -- adding as failsafe against runaway recursion which also shouldn't occur but just in case
---         utils:modPrint("Crawl steps exceeded "..tostring(enums.maxGutterCrawlSteps))
---         return square
---     end
-
---     local squareID = square:getID()
---     if hasDrainPipe then
---         gutterPipeMap[enums.pipeType.drain][squareID] = square
---         gutterPipeMap._drain_count = gutterPipeMap._drain_count + 1 -- NOTE: bit hacky but useful to not have to dynamically check the size of the dictionary in ui
---     end
---     if hasVerticalPipe then
---         gutterPipeMap[enums.pipeType.vertical][squareID] = square
---         gutterPipeMap._vertical_count = gutterPipeMap._vertical_count + 1 -- NOTE: bit hacky but useful to not have to dynamically check the size of the dictionary in ui
---     end
-
---     gutterPipeMap._all[squareID] = square
-
---     -- Following vertical pipes up z levels
---     local nextSquare = getCell():getGridSquare(square:getX(), square:getY(), square:getZ() + 1)
---     local crawlUp = self:crawlGutterSquare(nextSquare, gutterPipeMap, nil, crawlSteps) -- TODO up dir?
---     if crawlUp then
---         return crawlUp
---     end
-
---     -- TODO rethink response now that we check forked paths and won't have a singular final square
---     return square
--- end
-
--- TODO remove after validating new crawlGutterSquare function
--- ---@param square IsoGridSquare
--- ---@param gutterPipeMap GutterPipeMap
--- ---@param prevDir IsoDirections|nil
--- ---@param crawlSteps integer|nil
--- ---@return IsoGridSquare|nil
--- function isoUtils:crawlGutterSquare(square, gutterPipeMap, prevDir, crawlSteps)
---     if not square then return nil end
-
---     local squareProps = square:getProperties()
---     if not utils:isAnyPipeSquare(square, squareProps) then
---         return nil
---     elseif not prevDir and not utils:isVerticalPipeSquare(square, squareProps) and not utils:isDrainPipeSquare(square, squareProps) then
---         -- When no prevDir (coming up from below), ensure a vertical pipe exists before crawling
---         -- This is to prevent horizontal/gutter pipes from being included when there is no vertical pipe to connect them
---         -- TODO provide "up"/"down" prevDir if we want to reverse crawl and navigate top-down
---         return nil
---     end
-
---     if not crawlSteps then crawlSteps = 0 end
---     crawlSteps = crawlSteps + 1
---     if crawlSteps > enums.maxGutterCrawlSteps then
---         -- Shouldn't hit unless player builds a large system with more gutter objects
---         -- adding as failsafe against runaway recursion which also shouldn't occur but just in case
---         utils:modPrint("Crawl steps exceeded "..tostring(enums.maxGutterCrawlSteps))
---         return square
---     end
-
---     self:crawlHorizontalPipes(square, squareProps, gutterPipeMap, prevDir, crawlSteps)
---     self:crawlVerticalPipes(square, squareProps, gutterPipeMap, prevDir, crawlSteps)
-
---     -- TODO rethink response now that we check forked paths and won't have a singular final square
---     return square
--- end
-
 ---@param square IsoGridSquare
 ---@param pipeMap GutterPipeMap
 ---@return table<string, IsoGridSquare>|nil
@@ -506,29 +355,6 @@ function isoUtils:crawlPlayerBuildingRoofSquare(square, roofMap, dir, crawlSteps
     return square
 end
 
--- TODO remove after validating new crawlGutterPipes flood fill crawler
--- ---@param square IsoGridSquare
--- ---@return GutterPipeMap gutterPipeMap
--- function isoUtils:crawlGutterSystem(square)
---     ---@type GutterPipeMap
---     local gutterPipeMap = {
---         [enums.pipeType.drain] = {},
---         [enums.pipeType.vertical] = {},
---         [enums.pipeType.gutter] = {},
---         _all = {}, -- All squares that are part of the gutter system
---         _count = 0, -- Total count of squares in the gutter system
---         _drain_count = 0, -- Count of drain squares
---         _vertical_count = 0, -- Count of vertical squares
---         _gutter_count = 0, -- Count of gutter squares
---     }
---     local crawlSteps = 0
---     self:crawlGutterSquare(square, gutterPipeMap, nil, crawlSteps)
-
---     gutterPipeMap._count = utils:getDictSize(gutterPipeMap._all)
-
---     return gutterPipeMap
--- end
-
 ---@param startSquare IsoGridSquare
 ---@return GutterPipeMap gutterPipeMap
 function isoUtils:crawlGutterPipes(startSquare)
@@ -546,12 +372,14 @@ function isoUtils:crawlGutterPipes(startSquare)
     local crawlSteps = 0
     local visited = {}
     local queue = {startSquare}
+    local queued = {[startSquare:getID()] = true} -- Track queued squares to avoid duplicates
 
     -- NOTE: deep nesting if because no 'continue' in lua 5.2
     while #queue > 0 do
-        local square = table.remove(queue, 1)
+        local square = table.remove(queue, 1) -- Remove from queue list
         if square then
             local squareID = square:getID()
+            queued[squareID] = nil -- Remove from queued ref dict
             if not visited[squareID] then
                 -- Mark square as visited
                 visited[squareID] = true
@@ -565,7 +393,8 @@ function isoUtils:crawlGutterPipes(startSquare)
 
                     -- Add the next squares to the queue if they haven't been visited yet and don't already exist in the queue
                     for _, nextSquare in pairs(nextSquares) do
-                        if not visited[nextSquare:getID()] and not table_contains(queue, nextSquare) then
+                        local nextSquareID = nextSquare:getID()
+                        if not visited[nextSquareID] and not queued[nextSquareID] then
                             table_insert(queue, nextSquare)
                         end
                     end
@@ -583,9 +412,9 @@ function isoUtils:crawlGutterPipes(startSquare)
 
     -- Calculate metadata now that we have all the squares
     gutterPipeMap._count = utils:getDictSize(gutterPipeMap._all)
-    gutterPipeMap._drain_count = utils:getDictSize(gutterPipeMap[enums.pipeType.drain]) -- Ignore type hint warning
-    gutterPipeMap._vertical_count = utils:getDictSize(gutterPipeMap[enums.pipeType.vertical]) -- Ignore type hint warning
-    gutterPipeMap._gutter_count = utils:getDictSize(gutterPipeMap[enums.pipeType.gutter]) -- Ignore type hint warning
+    gutterPipeMap._drain_count = utils:getDictSize(gutterPipeMap[enums.pipeType.drain]) ---@diagnostic disable-line:param-type-mismatch
+    gutterPipeMap._vertical_count = utils:getDictSize(gutterPipeMap[enums.pipeType.vertical]) ---@diagnostic disable-line:param-type-mismatch
+    gutterPipeMap._gutter_count = utils:getDictSize(gutterPipeMap[enums.pipeType.gutter]) ---@diagnostic disable-line:param-type-mismatch
 
     return gutterPipeMap
 end
@@ -682,6 +511,7 @@ function isoUtils:findGutterTopLevel(square)
 end
 
 ---@param square IsoGridSquare
+---@return IsoBuilding|nil
 function isoUtils:getAttachedBuilding(square)
     -- Check square directly
     local squareBuilding = square:getBuilding()
@@ -694,6 +524,7 @@ function isoUtils:getAttachedBuilding(square)
 end
 
 ---@param pipeMap GutterPipeMap
+---@return integer topLevel
 function isoUtils:getGutterTopLevel(pipeMap)
     local topLevel = 0
 
@@ -707,140 +538,160 @@ function isoUtils:getGutterTopLevel(pipeMap)
     return topLevel
 end
 
----@param buildingDef BuildingDef
----@param zLevel integer
----@return GutterRoofMap floorSquares
-function isoUtils:getVanillaBuildingFloorSquares(buildingDef, zLevel)
-    local floorSquares = {}
-    local buildingDefRooms = buildingDef:getRooms()
-    for i=0, buildingDefRooms:size() - 1 do
-        local roomDef  = buildingDefRooms:get(i)
-        local roomZ = roomDef:getZ()
-        if roomZ == zLevel then
-            if roomDef:isEmptyOutside() then
-                -- Ignore empty outside rooms
-                utils:modPrint("Room is empty outside: "..tostring(roomDef:getID()))
-            else
-                local isoRoom = roomDef:getIsoRoom()
-                if isoRoom then
-                    local roomSquares = isoRoom:getSquares()
-                    for j=0, roomSquares:size() - 1 do
-                        local square = roomSquares:get(j)
-                        floorSquares[square:getID()] = square
-                    end
-                end
-            end
-        end
-    end
+---@param pipeMap GutterPipeMap
+---@param roofZ integer
+---@return table<string, IsoGridSquare> roofSeedSquares
+function isoUtils:findGutterRoofSeedSquares(pipeMap, roofZ)
+    -- Find all 'neighbor' squares for pipes that collect from roofZ level
+    -- NOTE: roofZ is the level above the gutter z level
+    local roofSeedSquares = {}
 
-    return floorSquares
-end
-
----@param square IsoGridSquare
----@param pipeMap GutterPipeMap|nil
----@param building IsoBuilding
----@return integer roofArea, GutterRoofMap roofSquares
-function isoUtils:getVanillaBuildingRoofAreaFromFloors(square, pipeMap, building)
-    -- NOTE: not used atm because building bounds strategy is more accurate for a broader set of configurations
-    if not pipeMap then
-        pipeMap = self:crawlGutterSystem(square)
-    end
-
-    local topGutterFloor = self:getGutterTopLevel(pipeMap)
-    local buildingDef = building:getDef()
-    local floorSquares = self:getVanillaBuildingFloorSquares(buildingDef, topGutterFloor)
-    local maxZ = buildingDef:getMaxLevel()
-    local roofArea = 0
-    local roofSquares = {}
-
-    for _, floorSquare in pairs(floorSquares) do
-        local squareX = floorSquare:getX()
-        local squareY = floorSquare:getY()
-        local squareZ = floorSquare:getZ()
-        local roofSquare = getCell():getGridSquare(squareX, squareY, squareZ + 1)
-        if squareZ == maxZ then
-            -- If the square is at the max level, then we can assume the square above is a valid roof
-            roofArea = roofArea + 1
-            roofSquares[roofSquare:getID()] = roofSquare
-        else
-            -- Otherwise check if the square above is valid
-            if self:isValidRoofSquare(roofSquare) then
-                roofArea = roofArea + 1
-                roofSquares[roofSquare:getID()] = roofSquare
-            end
-        end
-    end
-
-    return roofArea, roofSquares
-end
-
----@param square IsoGridSquare
----@param pipeMap GutterPipeMap|nil
----@param building IsoBuilding
----@return integer roofArea, GutterRoofMap roofSquares
-function isoUtils:getVanillaBuildingRoofAreaFromBounds(square, pipeMap, building)
-    -- NOTE: "bounds" strategy is generally more accurate for a broader set of configurations compared to "rooms" strategy 
-    -- but might be less performant for buildings that generate a large bounding rect compared to what space is actually occupied by the structure
-    if not pipeMap then
-        pipeMap = self:crawlGutterSystem(square)
-    end
-
-    local topGutterFloor = self:getGutterTopLevel(pipeMap)
-    local buildingDef = building:getDef()
-    local buildingBounds = {
-        x = buildingDef:getX(),
-        y = buildingDef:getY(),
-        x2 = buildingDef:getX2(),
-        y2 = buildingDef:getY2(),
-        w = buildingDef:getW(),
-        h = buildingDef:getH(),
+    local neighborDirections = {
+        localIsoDirections.N,
+        localIsoDirections.S,
+        localIsoDirections.E,
+        localIsoDirections.W,
+        localIsoDirections.NE,
+        localIsoDirections.NW
     }
-    local buildingDefId = buildingDef:getID() -- NOTE: different from IsoBuilding ID
-    local maxZ = buildingDef:getMaxLevel()
-    local minZ = buildingDef:getMinLevel()
-    local roofZ = topGutterFloor > maxZ and maxZ + 1 or topGutterFloor + 1
-    local roofArea = 0
-    local roofSquares = {}
 
-    local startX = buildingBounds.x
-    local startY = buildingBounds.y
-    local metaGrid = getWorld():getMetaGrid()
-    for x = 0, buildingBounds.w do
-        for y = 0, buildingBounds.h do
-            local squareX = startX + x
-            local squareY = startY + y
-
-            -- Verify square is 'associated' with the building
-            -- Roof squares are not in the bounds of the IsoBuilding but will still be associated with it from a meta grid perspective
-            -- Additionally, building bounds might intersect or overlap so we need to ensure roofs from other buildings are not included
-            local associatedBuilding = metaGrid:getAssociatedBuildingAt(squareX, squareY)
-            if associatedBuilding and associatedBuilding:getID() == buildingDefId then
-                local roofSquare = getCell():getGridSquare(squareX, squareY, roofZ)
-                -- Check if the square is valid to be considered a roof square
-                if roofSquare and self:isValidRoofSquare(roofSquare) then
-                    -- If the square doesn't have a floor, it might still be a valid roof but requires additional checks
-                    if not roofSquare:getFloor() then
-                        -- Verify the square is associated with a room on the min z level of the building (generally the 'ground' floor has the largest area of rooms)
-                        -- TODO check if this is the best way to determine if a square is part of a room as there are some holes
-                        -- maybe just check the square directly below for being inside or outside? if outside then ignore it
-                        local downSquare = getCell():getGridSquare(squareX, squareY, roofZ - 1)
-                        if downSquare and not downSquare:isOutside() then
-                            roofArea = roofArea + 1
-                            roofSquares[roofSquare:getID()] = roofSquare
-                        end
-                    else
-                        roofArea = roofArea + 1
-                        roofSquares[roofSquare:getID()] = roofSquare
+    for _, pipeSquare in pairs(pipeMap._all) do
+        if pipeSquare:getZ() + 1 == roofZ then
+            -- Check if the square is valid for starting the flood fill
+            local aboveSquare = getCell():getGridSquare(pipeSquare:getX(), pipeSquare:getY(), roofZ)
+            if aboveSquare then
+                for _, direction in ipairs(neighborDirections) do
+                    local neighborSquare = aboveSquare:getAdjacentSquare(direction)
+                    if neighborSquare then
+                        roofSeedSquares[neighborSquare:getID()] = neighborSquare
                     end
                 end
             end
+        end
+    end
 
-            -- Don't crawl the entirety of extremely large buildings (25x25 = 625 squares)
-            if y >= enums.maxBuildingBoundCrawlSteps then break end
+    return roofSeedSquares
+end
+
+---@param square IsoGridSquare
+---@return table<IsoGridSquare>
+function isoUtils:findRoofNeighborSquares(square)
+    -- Find all neighbors of the square at the specified roof level
+    local roofNeighborSquares = {}
+    local neighborDirections = {
+        localIsoDirections.N,
+        localIsoDirections.S,
+        localIsoDirections.E,
+        localIsoDirections.W,
+    }
+
+    for _, direction in ipairs(neighborDirections) do
+        local neighborSquare = square:getAdjacentSquare(direction)
+        if neighborSquare then
+            table_insert(roofNeighborSquares, neighborSquare)
+        end
+    end
+
+    return roofNeighborSquares
+end
+
+---@param square IsoGridSquare
+---@param buildingDefId integer
+---@return boolean
+function isoUtils:isValidVanillaRoofSquare(square, buildingDefId)
+    -- Verify square is 'associated' with the building
+    -- Roof squares are not in the bounds of the IsoBuilding but will still be associated with it from a meta grid perspective
+    -- Additionally, building bounds might intersect or overlap so we need to ensure roofs from other buildings are not included
+    if not square then
+        return false
+    end
+
+    local squareX = square:getX()
+    local squareY = square:getY()
+    local squareZ = square:getZ()
+    local metaGrid = getWorld():getMetaGrid()
+    local associatedBuilding = metaGrid:getAssociatedBuildingAt(squareX, squareY)
+    if associatedBuilding and associatedBuilding:getID() == buildingDefId then
+        -- Check if the square is valid to be considered a roof square
+        if self:isValidRoofSquare(square) then
+            -- If the square doesn't have a floor, it might still be a valid roof but requires additional checks
+            if not square:getFloor() then
+                -- Verify the square is associated with a room on the min z level of the building (generally the 'ground' floor has the largest area of rooms)
+                -- TODO check if this is the best way to determine if a square is part of a room as there are some holes
+                -- maybe just check the square directly below for being inside or outside? if outside then ignore it
+                local downSquare = getCell():getGridSquare(squareX, squareY, squareZ - 1)
+                if downSquare and not downSquare:isOutside() then
+                    return true
+                end
+            else
+                return true
+            end
+        end
+    end
+
+    return false
+end
+
+---@param square IsoGridSquare
+---@param pipeMap GutterPipeMap|nil
+---@param building IsoBuilding
+---@return integer roofArea, GutterRoofMap roofSquares
+function isoUtils:getVanillaBuildingRoofAreaFloodFill(square, pipeMap, building)
+    if not pipeMap then
+        pipeMap = self:crawlGutterPipes(square)
+    end
+
+    local topGutterFloor = self:getGutterTopLevel(pipeMap)
+    local buildingDef = building:getDef()
+    local buildingDefId = buildingDef:getID()
+    local maxZ = buildingDef:getMaxLevel()
+    local roofZ = topGutterFloor > maxZ and maxZ + 1 or topGutterFloor + 1
+
+    -- Initialize flood fill
+    local roofSquares = {}
+    local visited = {}
+    local queue = {}
+    local queued = {}
+    local roofArea = 0
+
+    -- Find starting point(s) around the roof-level pipes
+    local seedSquares = self:findGutterRoofSeedSquares(pipeMap, roofZ)
+    for seedSquareID, seedSquare in pairs(seedSquares) do
+        table.insert(queue, seedSquare)
+        queued[seedSquareID] = true
+    end
+
+    -- Flood fill to find connected roof area
+    while #queue > 0 do
+        local queuedSquare = table.remove(queue, 1)
+        local queuedSquareId = queuedSquare:getID()
+
+        if not visited[queuedSquareId] then
+            visited[queuedSquareId] = true
+            queued[queuedSquareId] = nil -- Remove from queued ref dict
+
+            -- Validate square belongs to building and is valid roof
+            if self:isValidVanillaRoofSquare(queuedSquare, buildingDefId) then
+                roofArea = roofArea + 1
+                roofSquares[queuedSquareId] = queuedSquare
+
+                -- Add neighbors to queue
+                local neighbors = self:findRoofNeighborSquares(queuedSquare)
+                for _, neighbor in ipairs(neighbors) do
+                    local neighborSquareId = neighbor:getID()
+                    if not visited[neighborSquareId] and not queued[neighborSquareId] then
+                        table_insert(queue, neighbor)
+                        queued[neighborSquareId] = true
+                    end
+                end
+            end
         end
 
-        -- Don't crawl the entirety of extremely large buildings (25x25 = 625 squares)
-        if x >= enums.maxBuildingBoundCrawlSteps then break end
+        -- Safety limit to stop on huge roofs
+        if roofArea > enums.maxRoofArea then
+            utils:modPrint("Roof flood fill exceeded maximum area")
+            break
+        end
     end
 
     return roofArea, roofSquares
@@ -855,7 +706,7 @@ function isoUtils:getGutterRoofArea(square, pipeMap)
     if building then
         -- Vanilla building mode
         buildingType = enums.buildingType.vanilla
-        roofArea, roofSquares = self:getVanillaBuildingRoofAreaFromBounds(square, pipeMap, building)
+        roofArea, roofSquares = self:getVanillaBuildingRoofAreaFloodFill(square, pipeMap, building)
     else
         -- Custom building mode
         buildingType = enums.buildingType.custom

--- a/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Iso.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Iso.lua
@@ -253,7 +253,15 @@ function isoUtils:crawlGutterSquare(square, pipeMap)
 
     if hasDrainPipe then
         -- Record in drain pipe map
-        pipeMap[enums.pipeType.drain][squareID] = square
+        local drainMap = pipeMap[enums.pipeType.drain]
+        if not drainMap.squares[squareID] then
+            drainMap.squares[squareID] = square
+            drainMap.count = drainMap.count + 1
+
+            if rootZ > drainMap.maxZ then
+                drainMap.maxZ = rootZ
+            end
+        end
 
         -- Drain pipes only connect to other pipes above
         local topSquare = rootCell:getGridSquare(rootX, rootY, rootZ + 1)
@@ -264,7 +272,15 @@ function isoUtils:crawlGutterSquare(square, pipeMap)
 
     if hasVerticalPipe then
         -- Record in vertical pipe map
-        pipeMap[enums.pipeType.vertical][squareID] = square
+        local verticalMap = pipeMap[enums.pipeType.vertical]
+        if not verticalMap.squares[squareID] then
+            verticalMap.squares[squareID] = square
+            verticalMap.count = verticalMap.count + 1
+
+            if rootZ > verticalMap.maxZ then
+                verticalMap.maxZ = rootZ
+            end
+        end
 
         -- Vertical pipes only connect to other pipes above and below
         local topSquare = rootCell:getGridSquare(rootX, rootY, rootZ + 1)
@@ -280,7 +296,15 @@ function isoUtils:crawlGutterSquare(square, pipeMap)
 
     if hasGutterPipe then
         -- Record in gutter pipe map
-        pipeMap[enums.pipeType.gutter][squareID] = square
+        local gutterMap = pipeMap[enums.pipeType.gutter]
+        if not gutterMap.squares[squareID] then
+            gutterMap.squares[squareID] = square
+            gutterMap.count = gutterMap.count + 1
+
+            if rootZ > gutterMap.maxZ then
+                gutterMap.maxZ = rootZ
+            end
+        end
 
         -- Gutter pipes connect to other pipes in the same z level 
         -- TODO verify above once we allow gutters to connect/support vertical pipes on next z level
@@ -305,6 +329,16 @@ function isoUtils:crawlGutterSquare(square, pipeMap)
         end
     end
 
+    if not pipeMap.all.squares[squareID] then
+        -- Add square to all squares map
+        pipeMap.all.squares[squareID] = square
+        pipeMap.all.count = pipeMap.all.count + 1
+
+        if rootZ > pipeMap.all.maxZ then
+             pipeMap.all.maxZ = rootZ
+        end
+    end
+
     return neighborSquares
 end
 
@@ -313,12 +347,13 @@ end
 ---@param dir IsoDirections|nil
 ---@param crawlSteps integer|nil
 ---@return IsoGridSquare|nil
-function isoUtils:crawlPlayerBuildingRoofSquare(square, roofMap, dir, crawlSteps)
+function isoUtils:crawlCustomBuildingRoofSquare(square, roofMap, dir, crawlSteps)
     if not square then
         utils:modPrint("No square found")
         return nil
     end
 
+    local squareZ = square:getZ()
     local squareModData = square:getModData()
     local isValidPlayerBuiltFloor = self:isValidPlayerBuiltFloor(square)
     if not isValidPlayerBuiltFloor then
@@ -329,7 +364,15 @@ function isoUtils:crawlPlayerBuildingRoofSquare(square, roofMap, dir, crawlSteps
         end
     else
         -- Add square to roof map
-        roofMap[square:getID()] = square
+        local squareID = square:getID()
+        if not roofMap.squares[squareID] then
+            roofMap.squares[squareID] = square
+            roofMap.count = roofMap.count + 1
+
+            if squareZ > roofMap.maxZ then
+                roofMap.maxZ = squareZ
+            end
+        end
 
         -- Add/sync the square's mod data
         squareModData[enums.modDataKey.isRoofSquare] = true
@@ -344,11 +387,11 @@ function isoUtils:crawlPlayerBuildingRoofSquare(square, roofMap, dir, crawlSteps
     -- Crawl to the next square
     local nextSquare
     if dir == IsoDirections.N then
-        nextSquare = getCell():getGridSquare(square:getX(), square:getY() - 1, square:getZ())
+        nextSquare = getCell():getGridSquare(square:getX(), square:getY() - 1, squareZ)
     else
-        nextSquare = getCell():getGridSquare(square:getX() - 1, square:getY(), square:getZ())
+        nextSquare = getCell():getGridSquare(square:getX() - 1, square:getY(), squareZ)
     end
-    local crawlNext = self:crawlPlayerBuildingRoofSquare(nextSquare, roofMap, dir, crawlSteps) -- TODO up dir?
+    local crawlNext = self:crawlCustomBuildingRoofSquare(nextSquare, roofMap, dir, crawlSteps) -- TODO up dir?
     if crawlNext then
         return crawlNext
     end
@@ -362,14 +405,26 @@ end
 function isoUtils:crawlGutterPipes(startSquare)
     ---@type GutterPipeMap
     local gutterPipeMap = {
-        [enums.pipeType.drain] = {},
-        [enums.pipeType.vertical] = {},
-        [enums.pipeType.gutter] = {},
-        _all = {}, -- All squares that are part of the gutter system
-        _count = 0, -- Total count of squares in the gutter system
-        _drain_count = 0, -- Count of drain squares
-        _vertical_count = 0, -- Count of vertical squares
-        _gutter_count = 0, -- Count of gutter squares
+        [enums.pipeType.drain] = {
+            squares = {},
+            count = 0,
+            maxZ = 0
+        },
+        [enums.pipeType.vertical] = {
+            squares = {},
+            count = 0,
+            maxZ = 0
+        },
+        [enums.pipeType.gutter] = {
+            squares = {},
+            count = 0,
+            maxZ = 0
+        },
+        all = {
+            squares = {},
+            count = 0,
+            maxZ = 0
+        },
     }
     local crawlSteps = 0
     local visited = {}
@@ -391,7 +446,6 @@ function isoUtils:crawlGutterPipes(startSquare)
                 if nextSquares ~= nil then
                     -- Update meta
                     crawlSteps = crawlSteps + 1
-                    gutterPipeMap._all[squareID] = square
 
                     -- Add the next squares to the queue if they haven't been visited yet and don't already exist in the queue
                     for _, nextSquare in pairs(nextSquares) do
@@ -412,12 +466,6 @@ function isoUtils:crawlGutterPipes(startSquare)
         end
     end
 
-    -- Calculate metadata now that we have all the squares
-    gutterPipeMap._count = utils:getDictSize(gutterPipeMap._all)
-    gutterPipeMap._drain_count = utils:getDictSize(gutterPipeMap[enums.pipeType.drain]) ---@diagnostic disable-line:param-type-mismatch
-    gutterPipeMap._vertical_count = utils:getDictSize(gutterPipeMap[enums.pipeType.vertical]) ---@diagnostic disable-line:param-type-mismatch
-    gutterPipeMap._gutter_count = utils:getDictSize(gutterPipeMap[enums.pipeType.gutter]) ---@diagnostic disable-line:param-type-mismatch
-
     return gutterPipeMap
 end
 
@@ -427,7 +475,7 @@ end
 function isoUtils:isSquareInGutterPipeMap(square, pipeMap)
     local squareID = square:getID()
 
-    if pipeMap._all[squareID] then
+    if pipeMap.all.squares[squareID] then
         return true
     end
 
@@ -436,10 +484,16 @@ end
 
 ---@param pipeMap GutterPipeMap
 ---@return GutterRoofMap roofMap
-function isoUtils:getPlayerBuildingRoofSquares(pipeMap)
-    local validRoofSquares = {}
+function isoUtils:crawlCustomBuildingRoof(pipeMap)
+    ---@type GutterRoofMap
+    local roofMap = {
+        squares = {},
+        count = 0,
+        maxZ = 0
+    }
 
-    for _, gutterSquare in pairs(pipeMap[enums.pipeType.gutter]) do
+    local gutterMap = pipeMap[enums.pipeType.gutter]
+    for _, gutterSquare in pairs(gutterMap.squares) do
         local _, _, spriteName, _ = utils:getSpriteCategoryMemberOnTile(gutterSquare, enums.pipeType.gutter)
         if not spriteName then
             -- Shouldn't happen but check just in case
@@ -455,7 +509,7 @@ function isoUtils:getPlayerBuildingRoofSquares(pipeMap)
             local attachedRoofX = gutterSquare:getX()
             local attachedRoofY = gutterSquare:getY() - 1
             local attachedRoofSquare = getCell():getGridSquare(attachedRoofX, attachedRoofY, gutterSquare:getZ() + 1)
-            self:crawlPlayerBuildingRoofSquare(attachedRoofSquare, validRoofSquares, IsoDirections.N, squareCrawlSteps)
+            self:crawlCustomBuildingRoofSquare(attachedRoofSquare, roofMap, IsoDirections.N, squareCrawlSteps)
         end
 
         if spriteDef.position == IsoDirections.W or fullCornerSprite then
@@ -463,29 +517,22 @@ function isoUtils:getPlayerBuildingRoofSquares(pipeMap)
             local attachedRoofX = gutterSquare:getX() - 1
             local attachedRoofY = gutterSquare:getY()
             local attachedRoofSquare = getCell():getGridSquare(attachedRoofX, attachedRoofY, gutterSquare:getZ() + 1)
-            self:crawlPlayerBuildingRoofSquare(attachedRoofSquare, validRoofSquares, IsoDirections.W, squareCrawlSteps)
+            self:crawlCustomBuildingRoofSquare(attachedRoofSquare, roofMap, IsoDirections.W, squareCrawlSteps)
         end
     end
 
-    return validRoofSquares
+    return roofMap
 end
 
 ---@param square IsoGridSquare
 ---@param pipeMap GutterPipeMap|nil
----@return integer roofArea, GutterRoofMap roofSquares
-function isoUtils:getPlayerBuildingRoofArea(square, pipeMap)
+---@return GutterRoofMap roofMap
+function isoUtils:getCustomBuildingRoofMap(square, pipeMap)
     if not pipeMap then
-        pipeMap = self:crawlGutterSystem(square)
+        pipeMap = self:crawlGutterPipes(square)
     end
 
-    local roofSquares = self:getPlayerBuildingRoofSquares(pipeMap)
-
-    local totalArea = 0
-    for _, _ in pairs(roofSquares) do
-        totalArea = totalArea + 1
-    end
-
-    return totalArea, roofSquares
+    return self:crawlCustomBuildingRoof(pipeMap)
 end
 
 ---@param square IsoGridSquare
@@ -526,21 +573,6 @@ function isoUtils:getAttachedBuilding(square)
 end
 
 ---@param pipeMap GutterPipeMap
----@return integer topLevel
-function isoUtils:getGutterTopLevel(pipeMap)
-    local topLevel = 0
-
-    for _, pipeSquare in pairs(pipeMap._all) do
-        local squareZ = pipeSquare:getZ()
-        if squareZ > topLevel then
-            topLevel = squareZ
-        end
-    end
-
-    return topLevel
-end
-
----@param pipeMap GutterPipeMap
 ---@param roofZ integer
 ---@return table<string, IsoGridSquare> roofSeedSquares
 function isoUtils:findGutterRoofSeedSquares(pipeMap, roofZ)
@@ -557,7 +589,7 @@ function isoUtils:findGutterRoofSeedSquares(pipeMap, roofZ)
         localIsoDirections.NW
     }
 
-    for _, pipeSquare in pairs(pipeMap._all) do
+    for _, pipeSquare in pairs(pipeMap.all.squares) do
         if pipeSquare:getZ() + 1 == roofZ then
             -- Check if the square is valid for starting the flood fill
             local aboveSquare = getCell():getGridSquare(pipeSquare:getX(), pipeSquare:getY(), roofZ)
@@ -637,24 +669,28 @@ end
 ---@param square IsoGridSquare
 ---@param pipeMap GutterPipeMap|nil
 ---@param building IsoBuilding
----@return integer roofArea, GutterRoofMap roofSquares
-function isoUtils:getVanillaBuildingRoofAreaFloodFill(square, pipeMap, building)
+---@return GutterRoofMap roofMap
+function isoUtils:getVanillaBuildingRoofMap(square, pipeMap, building)
     if not pipeMap then
         pipeMap = self:crawlGutterPipes(square)
     end
 
-    local topGutterFloor = self:getGutterTopLevel(pipeMap)
+    local topGutterFloor = pipeMap.all.maxZ
     local buildingDef = building:getDef()
     local buildingDefId = buildingDef:getID()
     local maxZ = buildingDef:getMaxLevel()
     local roofZ = topGutterFloor > maxZ and maxZ + 1 or topGutterFloor + 1
 
     -- Initialize flood fill
-    local roofSquares = {}
+    ---@type GutterRoofMap
+    local roofMap = {
+        squares = {},
+        count = 0,
+        maxZ = roofZ
+    }
     local visited = {}
     local queue = {}
     local queued = {}
-    local roofArea = 0
 
     -- Find starting point(s) around the roof-level pipes
     local seedSquares = self:findGutterRoofSeedSquares(pipeMap, roofZ)
@@ -674,8 +710,8 @@ function isoUtils:getVanillaBuildingRoofAreaFloodFill(square, pipeMap, building)
 
             -- Validate square belongs to building and is valid roof
             if self:isValidVanillaRoofSquare(queuedSquare, buildingDefId) then
-                roofArea = roofArea + 1
-                roofSquares[queuedSquareId] = queuedSquare
+                roofMap.squares[queuedSquareId] = queuedSquare
+                roofMap.count = roofMap.count + 1
 
                 -- Add neighbors to queue
                 local neighbors = self:findRoofNeighborSquares(queuedSquare)
@@ -690,32 +726,32 @@ function isoUtils:getVanillaBuildingRoofAreaFloodFill(square, pipeMap, building)
         end
 
         -- Safety limit to stop on huge roofs
-        if roofArea > enums.maxRoofArea then
+        if roofMap.count > enums.maxRoofArea then
             utils:modPrint("Roof flood fill exceeded maximum area")
             break
         end
     end
 
-    return roofArea, roofSquares
+    return roofMap
 end
 
 ---@param square IsoGridSquare
 ---@param pipeMap GutterPipeMap
----@return integer roofArea, GutterRoofMap roofSquares, BuildingType buildingType
-function isoUtils:getGutterRoofArea(square, pipeMap)
+---@return GutterRoofMap roofMap, BuildingType buildingType
+function isoUtils:getGutterRoofMap(square, pipeMap)
     local building = self:getAttachedBuilding(square)
-    local roofArea, roofSquares, buildingType
+    local roofMap, buildingType
     if building then
         -- Vanilla building mode
         buildingType = enums.buildingType.vanilla
-        roofArea, roofSquares = self:getVanillaBuildingRoofAreaFloodFill(square, pipeMap, building)
+        roofMap = self:getVanillaBuildingRoofMap(square, pipeMap, building)
     else
         -- Custom building mode
         buildingType = enums.buildingType.custom
-        roofArea, roofSquares = self:getPlayerBuildingRoofArea(square, pipeMap)
+        roofMap = self:getCustomBuildingRoofMap(square, pipeMap)
     end
 
-    return roofArea, roofSquares, buildingType
+    return roofMap, buildingType
 end
 
 ---@param square IsoGridSquare

--- a/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Iso.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Iso.lua
@@ -7,6 +7,7 @@ local localIsoDirections = IsoDirections
 local localIsoFlagType = IsoFlagType
 local table_insert = table.insert
 
+
 ---@param square IsoGridSquare
 ---@param north boolean
 ---@return integer x, integer y, integer z
@@ -230,11 +231,11 @@ end
 
 ---@param square IsoGridSquare
 ---@param squareProps PropertyContainer
----@param gutterSystemMap table
+---@param gutterPipeMap GutterPipeMap
 ---@param prevDir IsoDirections|nil
 ---@param crawlSteps integer|nil
 ---@return IsoGridSquare|nil
-function isoUtils:crawlHorizontalPipes(square, squareProps, gutterSystemMap, prevDir, crawlSteps)
+function isoUtils:crawlHorizontalPipes(square, squareProps, gutterPipeMap, prevDir, crawlSteps)
     if not square then return nil end
 
     local hasGutterPipe = utils:isGutterPipeSquare(square, squareProps)
@@ -254,40 +255,37 @@ function isoUtils:crawlHorizontalPipes(square, squareProps, gutterSystemMap, pre
     -- Try following gutter pipes north, south, east, west
     local _, squareGutter, spriteName, _ = utils:getSpriteCategoryMemberOnTile(square, enums.pipeType.gutter)
     if squareGutter then
-        table_insert(gutterSystemMap[enums.pipeType.gutter], square)
+        local squareID = square:getID()
+        gutterPipeMap[enums.pipeType.gutter][squareID] = square
+        gutterPipeMap._all[squareID] = square
+        gutterPipeMap._gutter_count = gutterPipeMap._gutter_count + 1 -- NOTE: bit hacky but useful to not have to dynamically check the size of the dictionary in ui
 
         local spriteDef = enums.pipes[spriteName]
         if spriteDef.position == localIsoDirections.N or spriteDef.position == localIsoDirections.NW then
-            local crawlWest = nil
-            local crawlEast = nil
-
             -- Check west
             if prevDir ~= localIsoDirections.E then
                 local westSquare = getCell():getGridSquare(square:getX() - 1, square:getY(), square:getZ())
-                crawlWest = self:crawlGutterSquare(westSquare, gutterSystemMap, localIsoDirections.W, crawlSteps)
+                self:crawlGutterSquare(westSquare, gutterPipeMap, localIsoDirections.W, crawlSteps)
             end
 
             -- Check east
             if prevDir ~= localIsoDirections.W then
                 local eastSquare = getCell():getGridSquare(square:getX() + 1, square:getY(), square:getZ())
-                crawlEast = self:crawlGutterSquare(eastSquare, gutterSystemMap, localIsoDirections.E, crawlSteps)
+                self:crawlGutterSquare(eastSquare, gutterPipeMap, localIsoDirections.E, crawlSteps)
             end
         end
 
         if spriteDef.position == localIsoDirections.W or spriteDef.position == localIsoDirections.NW then
-            local crawlNorth = nil
-            local crawlSouth = nil
-
             -- Check north
             if prevDir ~= localIsoDirections.S then
                 local northSquare = getCell():getGridSquare(square:getX(), square:getY() - 1, square:getZ())
-                crawlNorth = self:crawlGutterSquare(northSquare, gutterSystemMap, localIsoDirections.N, crawlSteps)
+                self:crawlGutterSquare(northSquare, gutterPipeMap, localIsoDirections.N, crawlSteps)
             end
 
             -- Check south
             if prevDir ~= localIsoDirections.N then
                 local southSquare = getCell():getGridSquare(square:getX(), square:getY() + 1, square:getZ())
-                crawlSouth = self:crawlGutterSquare(southSquare, gutterSystemMap, localIsoDirections.S, crawlSteps)
+                self:crawlGutterSquare(southSquare, gutterPipeMap, localIsoDirections.S, crawlSteps)
             end
         end
     end
@@ -298,11 +296,11 @@ end
 
 ---@param square IsoGridSquare
 ---@param squareProps PropertyContainer
----@param gutterSystemMap table
+---@param gutterPipeMap GutterPipeMap
 ---@param prevDir IsoDirections|nil
 ---@param crawlSteps integer|nil
 ---@return IsoGridSquare|nil
-function isoUtils:crawlVerticalPipes(square, squareProps, gutterSystemMap, prevDir, crawlSteps)
+function isoUtils:crawlVerticalPipes(square, squareProps, gutterPipeMap, prevDir, crawlSteps)
     if not square then return nil end
 
     local hasDrainPipe = utils:isDrainPipeSquare(square, squareProps)
@@ -320,16 +318,21 @@ function isoUtils:crawlVerticalPipes(square, squareProps, gutterSystemMap, prevD
         return square
     end
 
+    local squareID = square:getID()
     if hasDrainPipe then
-        table_insert(gutterSystemMap[enums.pipeType.drain], square)
+        gutterPipeMap[enums.pipeType.drain][squareID] = square
+        gutterPipeMap._drain_count = gutterPipeMap._drain_count + 1 -- NOTE: bit hacky but useful to not have to dynamically check the size of the dictionary in ui
     end
     if hasVerticalPipe then
-        table_insert(gutterSystemMap[enums.pipeType.vertical], square)
+        gutterPipeMap[enums.pipeType.vertical][squareID] = square
+        gutterPipeMap._vertical_count = gutterPipeMap._vertical_count + 1 -- NOTE: bit hacky but useful to not have to dynamically check the size of the dictionary in ui
     end
+
+    gutterPipeMap._all[squareID] = square
 
     -- Following vertical pipes up z levels
     local nextSquare = getCell():getGridSquare(square:getX(), square:getY(), square:getZ() + 1)
-    local crawlUp = self:crawlGutterSquare(nextSquare, gutterSystemMap, nil, crawlSteps) -- TODO up dir?
+    local crawlUp = self:crawlGutterSquare(nextSquare, gutterPipeMap, nil, crawlSteps) -- TODO up dir?
     if crawlUp then
         return crawlUp
     end
@@ -339,11 +342,11 @@ function isoUtils:crawlVerticalPipes(square, squareProps, gutterSystemMap, prevD
 end
 
 ---@param square IsoGridSquare
----@param gutterSystemMap table
+---@param gutterPipeMap GutterPipeMap
 ---@param prevDir IsoDirections|nil
 ---@param crawlSteps integer|nil
 ---@return IsoGridSquare|nil
-function isoUtils:crawlGutterSquare(square, gutterSystemMap, prevDir, crawlSteps)
+function isoUtils:crawlGutterSquare(square, gutterPipeMap, prevDir, crawlSteps)
     if not square then return nil end
 
     local squareProps = square:getProperties()
@@ -365,15 +368,15 @@ function isoUtils:crawlGutterSquare(square, gutterSystemMap, prevDir, crawlSteps
         return square
     end
 
-    self:crawlHorizontalPipes(square, squareProps, gutterSystemMap, prevDir, crawlSteps)
-    self:crawlVerticalPipes(square, squareProps, gutterSystemMap, prevDir, crawlSteps)
+    self:crawlHorizontalPipes(square, squareProps, gutterPipeMap, prevDir, crawlSteps)
+    self:crawlVerticalPipes(square, squareProps, gutterPipeMap, prevDir, crawlSteps)
 
     -- TODO rethink response now that we check forked paths and won't have a singular final square
     return square
 end
 
 ---@param square IsoGridSquare
----@param roofMap table
+---@param roofMap GutterRoofMap
 ---@param dir IsoDirections|nil
 ---@param crawlSteps integer|nil
 ---@return IsoGridSquare|nil
@@ -421,42 +424,48 @@ function isoUtils:crawlPlayerBuildingRoofSquare(square, roofMap, dir, crawlSteps
     return square
 end
 
----@param square any
----@return table pipeMap
+-- TODO rename to crawlGutterPipes so that "system" can be used for the entire gutter system including roofs and meta data
+---@param square IsoGridSquare
+---@return GutterPipeMap gutterPipeMap
 function isoUtils:crawlGutterSystem(square)
-    local gutterSystemMap = {
-        [enums.pipeType.drain] = table.newarray(),
-        [enums.pipeType.vertical] = table.newarray(),
-        [enums.pipeType.gutter] = table.newarray()
+    ---@type GutterPipeMap
+    local gutterPipeMap = {
+        [enums.pipeType.drain] = {},
+        [enums.pipeType.vertical] = {},
+        [enums.pipeType.gutter] = {},
+        _all = {}, -- All squares that are part of the gutter system
+        _count = 0, -- Total count of squares in the gutter system
+        _drain_count = 0, -- Count of drain squares
+        _vertical_count = 0, -- Count of vertical squares
+        _gutter_count = 0, -- Count of gutter squares
     }
     local crawlSteps = 0
-    self:crawlGutterSquare(square, gutterSystemMap, nil, crawlSteps)
-    return gutterSystemMap
+    self:crawlGutterSquare(square, gutterPipeMap, nil, crawlSteps)
+
+    gutterPipeMap._count = utils:getDictSize(gutterPipeMap._all)
+
+    return gutterPipeMap
 end
 
----@param square any
----@param pipeMap table
+---@param square IsoGridSquare
+---@param pipeMap GutterPipeMap
 ---@return boolean
 function isoUtils:isSquareInGutterPipeMap(square, pipeMap)
-    for _, pipeSquares in pairs(pipeMap) do
-        for i=1, #pipeSquares do
-            local gutterSquare = pipeSquares[i]
-            if square:getID() == gutterSquare:getID() then
-                return true
-            end
-        end
+    local squareID = square:getID()
+
+    if pipeMap._all[squareID] then
+        return true
     end
 
     return false
 end
 
----@param pipeMap table
----@return table<IsoGridSquare>
+---@param pipeMap GutterPipeMap
+---@return GutterRoofMap roofMap
 function isoUtils:getPlayerBuildingRoofSquares(pipeMap)
     local validRoofSquares = {}
 
-    for i=1, #pipeMap[enums.pipeType.gutter] do
-        local gutterSquare = pipeMap[enums.pipeType.gutter][i]
+    for _, gutterSquare in pairs(pipeMap[enums.pipeType.gutter]) do
         local _, _, spriteName, _ = utils:getSpriteCategoryMemberOnTile(gutterSquare, enums.pipeType.gutter)
         if not spriteName then
             -- Shouldn't happen but check just in case
@@ -487,8 +496,9 @@ function isoUtils:getPlayerBuildingRoofSquares(pipeMap)
     return validRoofSquares
 end
 
----@param pipeMap table
----@return integer roofArea, table<IsoGridSquare> roofSquares
+---@param square IsoGridSquare
+---@param pipeMap GutterPipeMap|nil
+---@return integer roofArea, GutterRoofMap roofSquares
 function isoUtils:getPlayerBuildingRoofArea(square, pipeMap)
     if not pipeMap then
         pipeMap = self:crawlGutterSystem(square)
@@ -497,7 +507,7 @@ function isoUtils:getPlayerBuildingRoofArea(square, pipeMap)
     local roofSquares = self:getPlayerBuildingRoofSquares(pipeMap)
 
     local totalArea = 0
-    for k, v in pairs(roofSquares) do
+    for _, _ in pairs(roofSquares) do
         totalArea = totalArea + 1
     end
 
@@ -540,19 +550,14 @@ function isoUtils:getAttachedBuilding(square)
     return self:getAdjacentBuilding(square)
 end
 
----@param pipeMap table
+---@param pipeMap GutterPipeMap
 function isoUtils:getGutterTopLevel(pipeMap)
     local topLevel = 0
-    for pipeType, pipeSquares in pairs(pipeMap) do
-        if pipeType == enums.pipeType.drain or pipeType == enums.pipeType.vertical then
-            -- Only check vertical or drain pipes
-            for i=1, #pipeSquares do
-                local gutterSquare = pipeSquares[i]
-                local squareZ = gutterSquare:getZ()
-                if squareZ > topLevel then
-                    topLevel = squareZ
-                end
-            end
+
+    for _, pipeSquare in pairs(pipeMap._all) do
+        local squareZ = pipeSquare:getZ()
+        if squareZ > topLevel then
+            topLevel = squareZ
         end
     end
 
@@ -561,7 +566,7 @@ end
 
 ---@param buildingDef BuildingDef
 ---@param zLevel integer
----@return table<IsoGridSquare> floorSquares
+---@return GutterRoofMap floorSquares
 function isoUtils:getVanillaBuildingFloorSquares(buildingDef, zLevel)
     local floorSquares = {}
     local buildingDefRooms = buildingDef:getRooms()
@@ -589,9 +594,9 @@ function isoUtils:getVanillaBuildingFloorSquares(buildingDef, zLevel)
 end
 
 ---@param square IsoGridSquare
----@param pipeMap table
+---@param pipeMap GutterPipeMap|nil
 ---@param building IsoBuilding
----@return integer roofArea, table<IsoGridSquare> roofSquares
+---@return integer roofArea, GutterRoofMap roofSquares
 function isoUtils:getVanillaBuildingRoofAreaFromFloors(square, pipeMap, building)
     -- NOTE: not used atm because building bounds strategy is more accurate for a broader set of configurations
     if not pipeMap then
@@ -627,9 +632,9 @@ function isoUtils:getVanillaBuildingRoofAreaFromFloors(square, pipeMap, building
 end
 
 ---@param square IsoGridSquare
----@param pipeMap table
+---@param pipeMap GutterPipeMap|nil
 ---@param building IsoBuilding
----@return integer roofArea, table<IsoGridSquare> roofSquares
+---@return integer roofArea, GutterRoofMap roofSquares
 function isoUtils:getVanillaBuildingRoofAreaFromBounds(square, pipeMap, building)
     -- NOTE: "bounds" strategy is generally more accurate for a broader set of configurations compared to "rooms" strategy 
     -- but might be less performant for buildings that generate a large bounding rect compared to what space is actually occupied by the structure
@@ -699,8 +704,8 @@ function isoUtils:getVanillaBuildingRoofAreaFromBounds(square, pipeMap, building
 end
 
 ---@param square IsoGridSquare
----@param pipeMap table
----@return integer roofArea, table<IsoGridSquare> roofSquares, "vanilla"|"custom" buildingType
+---@param pipeMap GutterPipeMap
+---@return integer roofArea, GutterRoofMap roofSquares, BuildingType buildingType
 function isoUtils:getGutterRoofArea(square, pipeMap)
     local building = self:getAttachedBuilding(square)
     local roofArea, roofSquares, buildingType
@@ -719,7 +724,7 @@ end
 
 ---@param square IsoGridSquare
 ---@param radius integer
----@param pipeType "drain"|"vertical"|"gutter"
+---@param pipeType PipeType
 ---@return IsoObject|nil
 function isoUtils:findPipeInRadius(square, radius, pipeType)
     local sx,sy,sz = square:getX(), square:getY(), square:getZ();

--- a/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Service.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Service.lua
@@ -28,7 +28,7 @@ function serviceUtils:isValidCollectorObject(object)
         return false
     end
 
-    return troughUtils:isTrough(object) or self:isFluidContainerObject(object)
+    return troughUtils:isTroughObject(object) or self:isFluidContainerObject(object)
 end
 
 ---@param object IsoObject

--- a/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Service.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Service.lua
@@ -279,23 +279,47 @@ function serviceUtils:hasSharedGutterPipes(primaryPipeMap, candidatePipeMap)
 end
 
 ---@param primaryDrainPipe IsoObject
----@param drainPipes table<IsoObject>
----@return table<IsoObject> relatedDrains
-function serviceUtils:filterGutterDrainsBySharedComponents(primaryDrainPipe, drainPipes)
+---@param drainPipes table<string, IsoObject>
+---@param sourcePipeMap GutterPipeMap
+---@param sourceRoofMap GutterRoofMap
+---@return table<string, IsoObject> relatedDrains
+function serviceUtils:filterGutterDrainsBySharedComponents(primaryDrainPipe, drainPipes, sourcePipeMap, sourceRoofMap)
     -- Filter the list of drain pipes by flood fill
     -- This is a more complex check that will take into account the connectedness of the drain pipes
     -- and their relationship to the primary drain pipe
-    -- Map all pipes and roof squares for each drain
-    local drainPipeMap = {}
-    local drainRoofMap = {}
-    for _, candidateDrain in ipairs(drainPipes) do
-        local candidateId = candidateDrain:getEntityNetID()
-        local candidateSquare = candidateDrain:getSquare()
+    local sourceDrainId = primaryDrainPipe:getEntityNetID()
 
-        -- TODO allow primaryPipeMap and primaryRoofMap to be passed in optionally
-        drainPipeMap[candidateId] = isoUtils:crawlGutterPipes(candidateSquare)
-        local _, drainRoofSquares, _ = isoUtils:getGutterRoofArea(candidateSquare, drainPipeMap[candidateId])
-        drainRoofMap[candidateId] = drainRoofSquares
+    if not sourcePipeMap then
+        sourcePipeMap = isoUtils:crawlGutterPipes(primaryDrainPipe:getSquare())
+    end
+
+    local drainPipeMap = {
+        [sourceDrainId] = sourcePipeMap
+    }
+
+    if not sourceRoofMap then
+        _, sourceRoofMap, _ = isoUtils:getGutterRoofArea(primaryDrainPipe:getSquare(), drainPipeMap[sourceDrainId])
+    end
+
+    local drainRoofMap = {
+        [sourceDrainId] = sourceRoofMap
+    }
+
+    for candidateId, candidateDrain in pairs(drainPipes) do
+        local candidateSquare = candidateDrain:getSquare()
+        local isSourceDrain = candidateId == sourceDrainId
+        if isSourceDrain and sourcePipeMap then
+            drainPipeMap[candidateId] = sourcePipeMap
+        else
+            drainPipeMap[candidateId] = isoUtils:crawlGutterPipes(candidateSquare)
+        end
+
+        if isSourceDrain and sourceRoofMap then
+            drainRoofMap[candidateId] = sourceRoofMap
+        else
+            local _, drainRoofSquares, _ = isoUtils:getGutterRoofArea(candidateSquare, drainPipeMap[candidateId])
+            drainRoofMap[candidateId] = drainRoofSquares
+        end
     end
 
     -- Cross-check each drain's pipeMap & roofMap for shared tiles
@@ -309,7 +333,11 @@ function serviceUtils:filterGutterDrainsBySharedComponents(primaryDrainPipe, dra
         -- Skip if already visited
         if not visited[drainId] then
             visited[drainId] = true
-            table_insert(relatedDrains, currentDrain)
+
+            -- Add the current drain to the related drains if it is not the source drain
+            if drainId ~= sourceDrainId then
+                relatedDrains[drainId] = currentDrain
+            end
 
             -- Get the pipe network for this drain
             local pipeMap = drainPipeMap[drainId]
@@ -324,10 +352,11 @@ function serviceUtils:filterGutterDrainsBySharedComponents(primaryDrainPipe, dra
                     local candidatePipeMap = drainPipeMap[candidateId]
                     local candidateRoofMap = drainRoofMap[candidateId]
 
+                    -- TODO maybe redundant now that we pre-filter siblings from the drainPipes param
                     -- Check for shared pipes
                     local hasSharedPipe = false
                     for candidatePipeSquareId, _ in pairs(candidatePipeMap._all) do
-                        if pipeMap[candidatePipeSquareId] then
+                        if pipeMap._all[candidatePipeSquareId] then
                             -- Both drain systems share a pipe square
                             hasSharedPipe = true
                             table_insert(queue, candidateDrain)
@@ -344,7 +373,6 @@ function serviceUtils:filterGutterDrainsBySharedComponents(primaryDrainPipe, dra
                                 break
                             end
                         end
-
                     end
                 end
             end
@@ -356,21 +384,20 @@ end
 
 
 ---@param primaryDrainPipe IsoObject
----@param drainPipes table<IsoObject>
+---@param drainPipes table<string,IsoObject>
 ---@param primaryBuilding IsoBuilding|nil
----@return table<IsoObject> relatedDrains
+---@return table<string, IsoObject> relatedDrains
 function serviceUtils:filterGutterDrainsByBuildingType(primaryDrainPipe, drainPipes, primaryBuilding)
     -- Determine if square has a pre-built building or is a player-built structure
-    local primaryDrainPipeSquare = primaryDrainPipe:getSquare()
-    local maxLevel = utils:getModDataMaxLevel(primaryDrainPipeSquare)
+    local primaryDrainSquare = primaryDrainPipe:getSquare()
+    local maxLevel = utils:getModDataMaxLevel(primaryDrainSquare)
 
     -- Reduce the list of drain pipes to only those relevant to the building mode
-    local associatedDrainPipes = table.newarray()
-    for i=1, #drainPipes do
-        local drainPipe = drainPipes[i]
-
+    local associatedDrainMap = {}
+    for drainPipeID, drainPipe in pairs(drainPipes) do
         -- Filter by connected status
         -- NOTE: pass through atm
+        local isAssociated = false
         local isDrainConnected = true -- utils:getModDataIsGutterConnected(drainPipe)
         if isDrainConnected then
             -- Filter by building type
@@ -386,80 +413,117 @@ function serviceUtils:filterGutterDrainsByBuildingType(primaryDrainPipe, drainPi
                         if pipeMaxLevel then
                             if pipeMaxLevel == maxLevel then
                                 -- Add the drain pipe to the list of associated pipes
-                                table_insert(associatedDrainPipes, drainPipe)
+                                isAssociated = true
                             end
                         else
                             -- If the drain pipe doesn't have a max level, go ahead an add it to the list of associated pipes
                             -- Would rather over estimate than under estimate
-                            table_insert(associatedDrainPipes, drainPipe)
+                            isAssociated = true
                         end
                     else
                         -- If for some reason the maxLevel is nil, go ahead an add it to the list of associated pipes
                         -- Would rather over estimate than under estimate
-                        table_insert(associatedDrainPipes, drainPipe)
+                        isAssociated = true
                     end
                 end
             else
                 -- Custom building type
                 -- Check if the drain is not attached to any building
                 if not drainBuilding then
-                    table_insert(associatedDrainPipes, drainPipe)
+                    isAssociated = true
                 end
             end
         end
+
+        if isAssociated then
+            associatedDrainMap[drainPipeID] = drainPipe
+        end
     end
 
-    return associatedDrainPipes
+    return associatedDrainMap
 end
 
----@param sourceDrainPipeSquare IsoGridSquare
----@return table<IsoObject>|nil drainPipes
-function serviceUtils:getAssociatedGutterDrains(sourceDrainPipeSquare)
-    local localDrainPipes = self:getLocalDrainPipes3D(sourceDrainPipeSquare, enums.defaultDrainPipeSearchRadius, enums.defaultDrainPipeSearchHeight)
+---@param sourceDrainSquare IsoGridSquare
+---@param sourcePipeMap GutterPipeMap
+---@param sourceRoofMap GutterRoofMap
+---@return table<string, IsoObject>|nil drainPipes
+function serviceUtils:getAssociatedGutterDrains(sourceDrainSquare, sourcePipeMap, sourceRoofMap)
+    local _, primaryDrainPipe, _, _ = utils:getSpriteCategoryMemberOnTile(sourceDrainSquare, enums.pipeType.drain)
+    if not primaryDrainPipe then
+        utils:modPrint("No primary drain pipe found on square: "..tostring(sourceDrainSquare))
+        return nil
+    end
+
+    -- Map drains connected to the primary drain
+    -- NOTE: includes the primary drain itself
+    local siblingDrainMap = {}
+    local siblingDrainCount = sourcePipeMap._drain_count
+    for _, siblingDrainSquare in pairs(sourcePipeMap[enums.pipeType.drain]) do
+        -- Get the drain pipe object on the sibling square
+        local _, siblingDrainPipe, _, _ = utils:getSpriteCategoryMemberOnTile(siblingDrainSquare, enums.pipeType.drain)
+        if siblingDrainPipe then
+            siblingDrainMap[siblingDrainPipe:getEntityNetID()] = siblingDrainPipe
+        end
+    end
+
+    -- Get all drains in 3d radius
+    local localDrainPipes = self:getLocalDrainPipes3D(sourceDrainSquare, enums.defaultDrainPipeSearchRadius, enums.defaultDrainPipeSearchHeight)
     if not localDrainPipes then
         return nil
     end
 
-    -- Return early if only 1 local drain pipe
-    if #localDrainPipes == 1 then
-        return localDrainPipes
+    -- Map local drains that are not siblings
+    local neighborDrainMap = {}
+    local neighborDrainCount = 0
+    for _, localDrainPipe in ipairs(localDrainPipes) do
+        local neighborDrainID = localDrainPipe:getEntityNetID()
+        if not siblingDrainMap[neighborDrainID] then
+            neighborDrainMap[neighborDrainID] = localDrainPipe
+            neighborDrainCount = neighborDrainCount + 1
+        end
     end
 
-    local _, primaryDrainPipe, _, _ = utils:getSpriteCategoryMemberOnTile(sourceDrainPipeSquare, enums.pipeType.drain)
-    if not primaryDrainPipe then
-        utils:modPrint("No primary drain pipe found on square: "..tostring(sourceDrainPipeSquare))
-        return nil
+    -- If there are no neighbor drains, return the sibling drains early
+    if neighborDrainCount == 0 then
+        return siblingDrainMap
     end
 
     -- Determine if square has a pre-built building or is a player-built structure
-    local primaryBuilding = isoUtils:getAttachedBuilding(sourceDrainPipeSquare)
+    local primaryBuilding = isoUtils:getAttachedBuilding(sourceDrainSquare)
 
     -- Reduce the list of drain pipes to only those relevant to the building mode
-    local associatedDrainPipes = self:filterGutterDrainsByBuildingType(primaryDrainPipe, localDrainPipes, primaryBuilding)
+    local associatedBuildingDrainMap = self:filterGutterDrainsByBuildingType(primaryDrainPipe, neighborDrainMap, primaryBuilding)
 
-    -- Return early if only 1 associated drain pipe after initial filtering
-    if #associatedDrainPipes == 1 then
-        return associatedDrainPipes
+    -- Return early if no non-sibling drains leftover after filter round 1
+    if utils:getDictSize(associatedBuildingDrainMap) == 0 then
+        return siblingDrainMap
     end
 
     -- If custom building type, apply more complex checks for shared pipes and roof tiles across the associated drain pipes
     if not primaryBuilding then
-        return self:filterGutterDrainsBySharedComponents(primaryDrainPipe, associatedDrainPipes)
+        associatedBuildingDrainMap = self:filterGutterDrainsBySharedComponents(primaryDrainPipe, associatedBuildingDrainMap, sourcePipeMap, sourceRoofMap)
     end
 
-    return associatedDrainPipes
+    -- Combine the sibling drains with the leftover associated drains
+    for drainID, drainPipe in pairs(associatedBuildingDrainMap) do
+        siblingDrainMap[drainID] = drainPipe
+    end
+
+    return siblingDrainMap
 end
 
 -- TODO pass in primaryPipeMap
----@param sourceDrainPipeSquare IsoGridSquare
+---@param sourceDrainSquare IsoGridSquare
+---@param sourcePipeMap GutterPipeMap
+---@param sourceRoofMap GutterRoofMap
 ---@return integer drainCount
-function serviceUtils:getAssociatedGutterDrainCount(sourceDrainPipeSquare)
-    local drainPipes = self:getAssociatedGutterDrains(sourceDrainPipeSquare)
+function serviceUtils:getAssociatedGutterDrainCount(sourceDrainSquare, sourcePipeMap, sourceRoofMap)
+    local drainPipes = self:getAssociatedGutterDrains(sourceDrainSquare, sourcePipeMap, sourceRoofMap)
     if not drainPipes then
         return 0
     end
 
-    return #drainPipes
+    return utils:getDictSize(drainPipes)
 end
 
 ---@param roofArea integer
@@ -613,7 +677,7 @@ function serviceUtils:calculateGutterSection(square)
 
     gutterSection.averageGutterCapacity = self:getAverageGutterCapacity()
     gutterSection.optimalDrainCount = self:getEstimatedGutterDrainCount(gutterSection.roofArea, gutterSection.averageGutterCapacity)
-    gutterSection.drainCount = self:getAssociatedGutterDrainCount(square)
+    gutterSection.drainCount = self:getAssociatedGutterDrainCount(square, gutterSection.pipeMap, gutterSection.roofMap)
     gutterSection.tileCount, gutterSection.overflowArea = self:calculateGutterSectionTileCount(gutterSection.roofArea, gutterSection.optimalDrainCount, gutterSection.drainCount, gutterSection.averageGutterCapacity)
     gutterSection.rainFactor = self:calculateGutterSectionRainFactor(gutterSection.tileCount)
 

--- a/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Service.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Service.lua
@@ -281,7 +281,7 @@ end
 ---@param primaryDrainPipe IsoObject
 ---@param drainPipes table<IsoObject>
 ---@return table<IsoObject> relatedDrains
-function serviceUtils:filterGutterDrainsByFloodFill(primaryDrainPipe, drainPipes)
+function serviceUtils:filterGutterDrainsBySharedComponents(primaryDrainPipe, drainPipes)
     -- Filter the list of drain pipes by flood fill
     -- This is a more complex check that will take into account the connectedness of the drain pipes
     -- and their relationship to the primary drain pipe
@@ -293,7 +293,7 @@ function serviceUtils:filterGutterDrainsByFloodFill(primaryDrainPipe, drainPipes
         local candidateSquare = candidateDrain:getSquare()
 
         -- TODO allow primaryPipeMap and primaryRoofMap to be passed in optionally
-        drainPipeMap[candidateId] = isoUtils:crawlGutterSystem(candidateSquare)
+        drainPipeMap[candidateId] = isoUtils:crawlGutterPipes(candidateSquare)
         local _, drainRoofSquares, _ = isoUtils:getGutterRoofArea(candidateSquare, drainPipeMap[candidateId])
         drainRoofMap[candidateId] = drainRoofSquares
     end
@@ -309,7 +309,7 @@ function serviceUtils:filterGutterDrainsByFloodFill(primaryDrainPipe, drainPipes
         -- Skip if already visited
         if not visited[drainId] then
             visited[drainId] = true
-            table.insert(relatedDrains, currentDrain)
+            table_insert(relatedDrains, currentDrain)
 
             -- Get the pipe network for this drain
             local pipeMap = drainPipeMap[drainId]
@@ -330,7 +330,7 @@ function serviceUtils:filterGutterDrainsByFloodFill(primaryDrainPipe, drainPipes
                         if pipeMap[candidatePipeSquareId] then
                             -- Both drain systems share a pipe square
                             hasSharedPipe = true
-                            table.insert(queue, candidateDrain)
+                            table_insert(queue, candidateDrain)
                             break
                         end
                     end
@@ -340,7 +340,7 @@ function serviceUtils:filterGutterDrainsByFloodFill(primaryDrainPipe, drainPipes
                         for candidateRoofSquareId, _ in pairs(candidateRoofMap) do
                             if roofMap[candidateRoofSquareId] then
                                 -- Both drain systems share a roof tile
-                                table.insert(queue, candidateDrain)
+                                table_insert(queue, candidateDrain)
                                 break
                             end
                         end
@@ -354,45 +354,31 @@ function serviceUtils:filterGutterDrainsByFloodFill(primaryDrainPipe, drainPipes
     return relatedDrains
 end
 
----@param sourceDrainPipeSquare IsoGridSquare
----@return table<IsoObject>|nil drainPipes
-function serviceUtils:getAssociatedGutterDrains(sourceDrainPipeSquare)
-    local localDrainPipes = self:getLocalDrainPipes3D(sourceDrainPipeSquare, enums.defaultDrainPipeSearchRadius, enums.defaultDrainPipeSearchHeight)
-    if not localDrainPipes then
-        return nil
-    end
 
-    -- Filter round 1 - use simple checks to reduce the list of drain pipes to those most likely to be 'related':
-    -- 1. filter by connected status (assume non-connected gutters are 'closed' and not collecting water)
-    -- 2. filter by building type 'vanilla' vs 'custom' (assume custom only relates to custom and vanilla only relates to vanilla)
-    -- 3.A if vanilla:
-    --     * filter by shared building id (assume different buildings are not related)
-    --     * filter by shared max level (assume if same max level then using same roof tiles)
-    -- 3.B if custom:
-    --  NOTE: use more complex checks to reduce the list of drain pipes to those that are 'related'
-    --      * filter by shared pipes
-    --      * filter by shared roof tiles
-
+---@param primaryDrainPipe IsoObject
+---@param drainPipes table<IsoObject>
+---@param primaryBuilding IsoBuilding|nil
+---@return table<IsoObject> relatedDrains
+function serviceUtils:filterGutterDrainsByBuildingType(primaryDrainPipe, drainPipes, primaryBuilding)
     -- Determine if square has a pre-built building or is a player-built structure
-    local squareBuilding = isoUtils:getAttachedBuilding(sourceDrainPipeSquare)
-    local maxLevel = utils:getModDataMaxLevel(sourceDrainPipeSquare)
+    local primaryDrainPipeSquare = primaryDrainPipe:getSquare()
+    local maxLevel = utils:getModDataMaxLevel(primaryDrainPipeSquare)
 
     -- Reduce the list of drain pipes to only those relevant to the building mode
-    -- Note: more involved filters are applied externally
     local associatedDrainPipes = table.newarray()
-    for i=1, #localDrainPipes do
-        local drainPipe = localDrainPipes[i]
+    for i=1, #drainPipes do
+        local drainPipe = drainPipes[i]
 
-        -- 1. Filter by connected status
+        -- Filter by connected status
         -- NOTE: pass through atm
         local isDrainConnected = true -- utils:getModDataIsGutterConnected(drainPipe)
         if isDrainConnected then
-            -- 2. Filter by building type
+            -- Filter by building type
             local drainBuilding = isoUtils:getAttachedBuilding(drainPipe:getSquare())
-            if squareBuilding then
-                -- 3.A Vanilla building mode
+            if primaryBuilding then
+                -- Vanilla building type
                 -- Check if the drain pipe is attached to the same building
-                if drainBuilding and drainBuilding:getID() == squareBuilding:getID() then
+                if drainBuilding and drainBuilding:getID() == primaryBuilding:getID() then
                     -- Check if drains on the same building are getting water from the same level
                     if maxLevel then
                         local drainPipeSquare = drainPipe:getSquare()
@@ -414,7 +400,7 @@ function serviceUtils:getAssociatedGutterDrains(sourceDrainPipeSquare)
                     end
                 end
             else
-                -- 3.B Custom building mode
+                -- Custom building type
                 -- Check if the drain is not attached to any building
                 if not drainBuilding then
                     table_insert(associatedDrainPipes, drainPipe)
@@ -423,13 +409,42 @@ function serviceUtils:getAssociatedGutterDrains(sourceDrainPipeSquare)
         end
     end
 
-    -- TODO 3.B flood fill for custom drains
-    if not squareBuilding then
-        local _, primaryDrainPipe, _, _ = utils:getSpriteCategoryMemberOnTile(sourceDrainPipeSquare, enums.pipeType.drain)
-        if primaryDrainPipe then
-            utils:modPrint("Custom building mode detected. Performing flood fill for associated gutter drains.")
-            return self:filterGutterDrainsByFloodFill(primaryDrainPipe, associatedDrainPipes)
-        end
+    return associatedDrainPipes
+end
+
+---@param sourceDrainPipeSquare IsoGridSquare
+---@return table<IsoObject>|nil drainPipes
+function serviceUtils:getAssociatedGutterDrains(sourceDrainPipeSquare)
+    local localDrainPipes = self:getLocalDrainPipes3D(sourceDrainPipeSquare, enums.defaultDrainPipeSearchRadius, enums.defaultDrainPipeSearchHeight)
+    if not localDrainPipes then
+        return nil
+    end
+
+    -- Return early if only 1 local drain pipe
+    if #localDrainPipes == 1 then
+        return localDrainPipes
+    end
+
+    local _, primaryDrainPipe, _, _ = utils:getSpriteCategoryMemberOnTile(sourceDrainPipeSquare, enums.pipeType.drain)
+    if not primaryDrainPipe then
+        utils:modPrint("No primary drain pipe found on square: "..tostring(sourceDrainPipeSquare))
+        return nil
+    end
+
+    -- Determine if square has a pre-built building or is a player-built structure
+    local primaryBuilding = isoUtils:getAttachedBuilding(sourceDrainPipeSquare)
+
+    -- Reduce the list of drain pipes to only those relevant to the building mode
+    local associatedDrainPipes = self:filterGutterDrainsByBuildingType(primaryDrainPipe, localDrainPipes, primaryBuilding)
+
+    -- Return early if only 1 associated drain pipe after initial filtering
+    if #associatedDrainPipes == 1 then
+        return associatedDrainPipes
+    end
+
+    -- If custom building type, apply more complex checks for shared pipes and roof tiles across the associated drain pipes
+    if not primaryBuilding then
+        return self:filterGutterDrainsBySharedComponents(primaryDrainPipe, associatedDrainPipes)
     end
 
     return associatedDrainPipes
@@ -578,7 +593,7 @@ function serviceUtils:calculateGutterSection(square)
         return nil
     end
 
-    gutterSection.pipeMap = isoUtils:crawlGutterSystem(square)
+    gutterSection.pipeMap = isoUtils:crawlGutterPipes(square)
     local roofArea, roofMap, buildingType = isoUtils:getGutterRoofArea(square, gutterSection.pipeMap)
     if not roofArea then
         utils:modPrint("No roof area found for square: "..tostring(square))

--- a/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Service.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Service.lua
@@ -223,7 +223,7 @@ function serviceUtils:getLocalDrainPipes3D(square, radius, zRadius)
     local x = square:getX()
     local y = square:getY()
     local z =  square:getZ()
-    for i=1, zRadius + 1 do -- TODO can't remember why +1?
+    for i=1, zRadius + 1 do
         -- Check up zRadius levels
         local upZ = z + i
         local upSquare = square:getCell():getGridSquare(x, y, upZ)
@@ -259,25 +259,6 @@ function serviceUtils:getLocalDrainPipes3D(square, radius, zRadius)
     return drainPipes
 end
 
-
----@param primaryPipeMap table<IsoObject>
----@param candidatePipeMap table<IsoObject>
----@return boolean
-function serviceUtils:hasSharedGutterPipes(primaryPipeMap, candidatePipeMap)
-    -- Check if the candidate drain pipe shares any pipes with the primary drain pipe
-    for pipeType, primaryPipes in pairs(primaryPipeMap) do
-        -- Check each pipe category 
-        local candidateTypePipes = candidatePipeMap[pipeType]
-        for _, primaryPipe in pairs(primaryPipes) do
-            if candidateTypePipes[primaryPipe] then
-                return true
-            end
-        end
-    end
-
-    return false
-end
-
 ---@param primaryDrainPipe IsoObject
 ---@param drainPipes table<string, IsoObject>
 ---@param sourcePipeMap GutterPipeMap
@@ -298,27 +279,27 @@ function serviceUtils:filterGutterDrainsBySharedComponents(primaryDrainPipe, dra
     }
 
     if not sourceRoofMap then
-        _, sourceRoofMap, _ = isoUtils:getGutterRoofArea(primaryDrainPipe:getSquare(), drainPipeMap[sourceDrainId])
+        sourceRoofMap, _ = isoUtils:getGutterRoofMap(primaryDrainPipe:getSquare(), drainPipeMap[sourceDrainId])
     end
 
     local drainRoofMap = {
         [sourceDrainId] = sourceRoofMap
     }
 
-    for candidateId, candidateDrain in pairs(drainPipes) do
+    for candidateDrainId, candidateDrain in pairs(drainPipes) do
         local candidateSquare = candidateDrain:getSquare()
-        local isSourceDrain = candidateId == sourceDrainId
+        local isSourceDrain = candidateDrainId == sourceDrainId
         if isSourceDrain and sourcePipeMap then
-            drainPipeMap[candidateId] = sourcePipeMap
+            drainPipeMap[candidateDrainId] = sourcePipeMap
         else
-            drainPipeMap[candidateId] = isoUtils:crawlGutterPipes(candidateSquare)
+            drainPipeMap[candidateDrainId] = isoUtils:crawlGutterPipes(candidateSquare)
         end
 
         if isSourceDrain and sourceRoofMap then
-            drainRoofMap[candidateId] = sourceRoofMap
+            drainRoofMap[candidateDrainId] = sourceRoofMap
         else
-            local _, drainRoofSquares, _ = isoUtils:getGutterRoofArea(candidateSquare, drainPipeMap[candidateId])
-            drainRoofMap[candidateId] = drainRoofSquares
+            local candidateRoofMap, _ = isoUtils:getGutterRoofMap(candidateSquare, drainPipeMap[candidateDrainId])
+            drainRoofMap[candidateDrainId] = candidateRoofMap
         end
     end
 
@@ -346,17 +327,19 @@ function serviceUtils:filterGutterDrainsBySharedComponents(primaryDrainPipe, dra
             -- Find all other drains connected through this network
             -- NOTE: implicit self-check since currentDrain already added to visited
             for _, candidateDrain in ipairs(drainPipes) do
-                local candidateId = candidateDrain:getEntityNetID()
-                if not visited[candidateId] then
+                local candidateDrainId = candidateDrain:getEntityNetID()
+                if not visited[candidateDrainId] then
 
-                    local candidatePipeMap = drainPipeMap[candidateId]
-                    local candidateRoofMap = drainRoofMap[candidateId]
+                    local candidatePipeMap = drainPipeMap[candidateDrainId]
+                    local candidateRoofMap = drainRoofMap[candidateDrainId]
 
                     -- TODO maybe redundant now that we pre-filter siblings from the drainPipes param
                     -- Check for shared pipes
                     local hasSharedPipe = false
-                    for candidatePipeSquareId, _ in pairs(candidatePipeMap._all) do
-                        if pipeMap._all[candidatePipeSquareId] then
+                    local candidatePipeSquares = candidatePipeMap.all.squares
+                    local sourcePipeSquares = pipeMap.all.squares
+                    for candidatePipeSquareId, _ in pairs(candidatePipeSquares) do
+                        if sourcePipeSquares[candidatePipeSquareId] then
                             -- Both drain systems share a pipe square
                             hasSharedPipe = true
                             table_insert(queue, candidateDrain)
@@ -366,8 +349,8 @@ function serviceUtils:filterGutterDrainsBySharedComponents(primaryDrainPipe, dra
 
                     -- Check for shared roof tiles
                     if not hasSharedPipe then
-                        for candidateRoofSquareId, _ in pairs(candidateRoofMap) do
-                            if roofMap[candidateRoofSquareId] then
+                        for candidateRoofSquareId, _ in pairs(candidateRoofMap.squares) do
+                            if roofMap.squares[candidateRoofSquareId] then
                                 -- Both drain systems share a roof tile
                                 table_insert(queue, candidateDrain)
                                 break
@@ -457,8 +440,8 @@ function serviceUtils:getAssociatedGutterDrains(sourceDrainSquare, sourcePipeMap
     -- Map drains connected to the primary drain
     -- NOTE: includes the primary drain itself
     local siblingDrainMap = {}
-    local siblingDrainCount = sourcePipeMap._drain_count
-    for _, siblingDrainSquare in pairs(sourcePipeMap[enums.pipeType.drain]) do
+    local siblingDrainSquares = sourcePipeMap[enums.pipeType.drain].squares
+    for _, siblingDrainSquare in pairs(siblingDrainSquares) do
         -- Get the drain pipe object on the sibling square
         local _, siblingDrainPipe, _, _ = utils:getSpriteCategoryMemberOnTile(siblingDrainSquare, enums.pipeType.drain)
         if siblingDrainPipe then
@@ -512,20 +495,6 @@ function serviceUtils:getAssociatedGutterDrains(sourceDrainSquare, sourcePipeMap
     return siblingDrainMap
 end
 
--- TODO pass in primaryPipeMap
----@param sourceDrainSquare IsoGridSquare
----@param sourcePipeMap GutterPipeMap
----@param sourceRoofMap GutterRoofMap
----@return integer drainCount
-function serviceUtils:getAssociatedGutterDrainCount(sourceDrainSquare, sourcePipeMap, sourceRoofMap)
-    local drainPipes = self:getAssociatedGutterDrains(sourceDrainSquare, sourcePipeMap, sourceRoofMap)
-    if not drainPipes then
-        return 0
-    end
-
-    return utils:getDictSize(drainPipes)
-end
-
 ---@param roofArea integer
 ---@param averageGutterCapacity integer|nil
 ---@return integer optimalDrainCount
@@ -576,16 +545,13 @@ function serviceUtils:calculateGutterSectionTileCount(roofArea, optimalDrainCoun
         -- Set the gutter tile count to the average (max) capacity and calculate remainder as overflow
         gutterTileCount = averageGutterCapacity
         local gutterCapacityOverflow = overflowArea
-        -- utils:modPrint("Gutter overflow capacity: "..tostring(gutterCapacityOverflow))
 
         -- Overflow 'tile' is only 25% as effective since the system is overloaded
         local gutterOverflowTileCount = gutterCapacityOverflow * enums.gutterSectionOverflowEfficiency
-        -- utils:modPrint("Gutter overflow tile count: "..tostring(gutterOverflowTileCount))
 
         -- Prevent the overflow capacity from exceeding 25% of the average gutter capacity
         local maxOverflowArea = averageGutterCapacity * enums.gutterSectionOverflowEfficiency
         if gutterOverflowTileCount > maxOverflowArea then
-            -- utils:modPrint("Gutter overflow capacity exceeds max: "..tostring(maxOverflowArea))
             gutterOverflowTileCount = maxOverflowArea
         end
 
@@ -606,9 +572,7 @@ end
 function serviceUtils:calculateGutterSectionRainFactor(gutterTileCount)
     -- Aim for this value to be 1.0 with mod options between 0.0 and 2.0
     local roofTileRainFactor = options:getRoofRainFactor()
-    local gutterEfficiencyFactor = 1
-    -- TODO each gutter pipe can has its own factor based on 'quality' up to 95% efficiency
-    -- TODO should take an average of quality across all connected gutter pipes
+    local gutterEfficiencyFactor = 1 -- Potentially introduce material tiers in the future (ex: clay vs metal)
 
     -- The total factor for the specific pipe based on it's own gutter efficiency
     return gutterTileCount * gutterEfficiencyFactor / 10 * roofTileRainFactor
@@ -644,7 +608,8 @@ function serviceUtils:calculateGutterSection(square)
         pipeMap = nil,
         roofMap = nil,
         buildingType = nil,
-        maxLevel = nil,
+        drains = nil,
+        maxLevel = 0,
         averageGutterCapacity = 0,
         overflowArea = 0,
         overflowEfficiency = enums.gutterSectionOverflowEfficiency,
@@ -658,16 +623,17 @@ function serviceUtils:calculateGutterSection(square)
     end
 
     gutterSection.pipeMap = isoUtils:crawlGutterPipes(square)
-    local roofArea, roofMap, buildingType = isoUtils:getGutterRoofArea(square, gutterSection.pipeMap)
-    if not roofArea then
-        utils:modPrint("No roof area found for square: "..tostring(square))
-        return gutterSection
-    end
+    gutterSection.roofMap, gutterSection.buildingType = isoUtils:getGutterRoofMap(square, gutterSection.pipeMap)
+    gutterSection.roofArea = gutterSection.roofMap.count
+    gutterSection.maxLevel = gutterSection.roofMap.maxZ -- TODO if no roof squares, need to handle that case
 
-    gutterSection.roofArea = roofArea
-    gutterSection.roofMap = roofMap
-    gutterSection.buildingType = buildingType
-    gutterSection.maxLevel = isoUtils:getGutterTopLevel(gutterSection.pipeMap) + 1
+    gutterSection.drains = self:getAssociatedGutterDrains(square, gutterSection.pipeMap, gutterSection.roofMap)
+    gutterSection.drainCount = gutterSection.drains and utils:getDictSize(gutterSection.drains) or 0 -- NOTE: shouldn't ever be 0 since we already validate drain exists earlier in this function
+
+    gutterSection.averageGutterCapacity = self:getAverageGutterCapacity()
+    gutterSection.optimalDrainCount = self:getEstimatedGutterDrainCount(gutterSection.roofArea, gutterSection.averageGutterCapacity)
+    gutterSection.tileCount, gutterSection.overflowArea = self:calculateGutterSectionTileCount(gutterSection.roofArea, gutterSection.optimalDrainCount, gutterSection.drainCount, gutterSection.averageGutterCapacity)
+    gutterSection.rainFactor = self:calculateGutterSectionRainFactor(gutterSection.tileCount)
 
     -- Persist some data on the square for quick checks
     local squareModData = square:getModData()
@@ -675,17 +641,6 @@ function serviceUtils:calculateGutterSection(square)
     squareModData[enums.modDataKey.buildingType] = gutterSection.buildingType
     squareModData[enums.modDataKey.maxLevel] = gutterSection.maxLevel
 
-    gutterSection.averageGutterCapacity = self:getAverageGutterCapacity()
-    gutterSection.optimalDrainCount = self:getEstimatedGutterDrainCount(gutterSection.roofArea, gutterSection.averageGutterCapacity)
-    gutterSection.drainCount = self:getAssociatedGutterDrainCount(square, gutterSection.pipeMap, gutterSection.roofMap)
-    gutterSection.tileCount, gutterSection.overflowArea = self:calculateGutterSectionTileCount(gutterSection.roofArea, gutterSection.optimalDrainCount, gutterSection.drainCount, gutterSection.averageGutterCapacity)
-    gutterSection.rainFactor = self:calculateGutterSectionRainFactor(gutterSection.tileCount)
-
-    -- utils:modPrint("Roof area: "..tostring(gutterSection.roofArea))
-    -- utils:modPrint("Optimal drain count: "..tostring(gutterSection.optimalDrainCount))
-    -- utils:modPrint("Actual drain count: "..tostring(gutterSection.drainCount))
-    -- utils:modPrint("Section tile count: "..tostring(gutterSection.tileCount))
-    -- utils:modPrint("Section rain factor: "..tostring(gutterSection.rainFactor))
     return gutterSection
 end
 

--- a/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Service.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Service.lua
@@ -87,6 +87,7 @@ function serviceUtils:getDrainPipeSquareFromCollector(collectorObject)
     end
 
     if troughUtils:isTrough(collectorObject) then
+        -- TODO REDO - will need to iterate through all connected troughs to find the drain pipe square
         -- Check if the other trough object is located on a square with a drain pipe
         local otherTroughObject = troughUtils:getOtherTroughObject(collectorObject)
         if not otherTroughObject then
@@ -200,50 +201,7 @@ function serviceUtils:getLocalDrainPipes(square, radius)
         return nil
     end
 
-    -- Determine if square has a pre-built building or is a player-built structure
-    local squareBuilding = isoUtils:getAttachedBuilding(square)
-
-    local maxLevel = utils:getModDataMaxLevel(square)
-
-    -- Reduce the list of drain pipes to only those relevant to the building mode
-    local associatedDrainPipes = table.newarray()
-    for i=1, #drainPipes do
-        local drainPipe = drainPipes[i]
-        local drainBuilding = isoUtils:getAttachedBuilding(drainPipe:getSquare())
-        if squareBuilding then
-            -- Vanilla building mode
-            -- Check if the drain pipe is attached to the same building
-            if drainBuilding and drainBuilding:getID() == squareBuilding:getID() then
-                -- Check if drains on the same building are getting water from the same level
-                if maxLevel then
-                    local drainPipeSquare = drainPipe:getSquare()
-                    local pipeMaxLevel = utils:getModDataMaxLevel(drainPipeSquare)
-                    if pipeMaxLevel then
-                        if pipeMaxLevel == maxLevel then
-                            -- Add the drain pipe to the list of associated pipes
-                            table_insert(associatedDrainPipes, drainPipe)
-                        end
-                    else
-                        -- If the drain pipe doesn't have a max level, go ahead an add it to the list of associated pipes
-                        -- Would rather over estimate than under estimate
-                        table_insert(associatedDrainPipes, drainPipe)
-                    end
-                else
-                    -- If for some reason the maxLevel is nil, go ahead an add it to the list of associated pipes
-                    -- Would rather over estimate than under estimate
-                    table_insert(associatedDrainPipes, drainPipe)
-                end
-            end
-        else
-            -- Custom building mode
-            -- Check if the drain is not attached to any building
-            if not drainBuilding then
-                table_insert(associatedDrainPipes, drainPipe)
-            end
-        end
-    end
-
-    return associatedDrainPipes
+    return drainPipes
 end
 
 ---@param square IsoGridSquare
@@ -301,10 +259,187 @@ function serviceUtils:getLocalDrainPipes3D(square, radius, zRadius)
     return drainPipes
 end
 
----@param square IsoGridSquare
+
+---@param primaryPipeMap table<IsoObject>
+---@param candidatePipeMap table<IsoObject>
+---@return boolean
+function serviceUtils:hasSharedGutterPipes(primaryPipeMap, candidatePipeMap)
+    -- Check if the candidate drain pipe shares any pipes with the primary drain pipe
+    for pipeType, primaryPipes in pairs(primaryPipeMap) do
+        -- Check each pipe category 
+        local candidateTypePipes = candidatePipeMap[pipeType]
+        for _, primaryPipe in pairs(primaryPipes) do
+            if candidateTypePipes[primaryPipe] then
+                return true
+            end
+        end
+    end
+
+    return false
+end
+
+---@param primaryDrainPipe IsoObject
+---@param drainPipes table<IsoObject>
+---@return table<IsoObject> relatedDrains
+function serviceUtils:filterGutterDrainsByFloodFill(primaryDrainPipe, drainPipes)
+    -- Filter the list of drain pipes by flood fill
+    -- This is a more complex check that will take into account the connectedness of the drain pipes
+    -- and their relationship to the primary drain pipe
+    -- Map all pipes and roof squares for each drain
+    local drainPipeMap = {}
+    local drainRoofMap = {}
+    for _, candidateDrain in ipairs(drainPipes) do
+        local candidateId = candidateDrain:getEntityNetID()
+        local candidateSquare = candidateDrain:getSquare()
+
+        -- TODO allow primaryPipeMap and primaryRoofMap to be passed in optionally
+        drainPipeMap[candidateId] = isoUtils:crawlGutterSystem(candidateSquare)
+        local _, drainRoofSquares, _ = isoUtils:getGutterRoofArea(candidateSquare, drainPipeMap[candidateId])
+        drainRoofMap[candidateId] = drainRoofSquares
+    end
+
+    -- Cross-check each drain's pipeMap & roofMap for shared tiles
+    local visited = {}
+    local relatedDrains = {}
+    local queue = {primaryDrainPipe} -- Start with the primary drain pipe
+    while #queue > 0 do
+        local currentDrain = table.remove(queue, 1)
+        local drainId = currentDrain:getEntityNetID()
+
+        -- Skip if already visited
+        if not visited[drainId] then
+            visited[drainId] = true
+            table.insert(relatedDrains, currentDrain)
+
+            -- Get the pipe network for this drain
+            local pipeMap = drainPipeMap[drainId]
+            local roofMap = drainRoofMap[drainId]
+
+            -- Find all other drains connected through this network
+            -- NOTE: implicit self-check since currentDrain already added to visited
+            for _, candidateDrain in ipairs(drainPipes) do
+                local candidateId = candidateDrain:getEntityNetID()
+                if not visited[candidateId] then
+
+                    local candidatePipeMap = drainPipeMap[candidateId]
+                    local candidateRoofMap = drainRoofMap[candidateId]
+
+                    -- Check for shared pipes
+                    local hasSharedPipe = false
+                    for candidatePipeSquareId, _ in pairs(candidatePipeMap._all) do
+                        if pipeMap[candidatePipeSquareId] then
+                            -- Both drain systems share a pipe square
+                            hasSharedPipe = true
+                            table.insert(queue, candidateDrain)
+                            break
+                        end
+                    end
+
+                    -- Check for shared roof tiles
+                    if not hasSharedPipe then
+                        for candidateRoofSquareId, _ in pairs(candidateRoofMap) do
+                            if roofMap[candidateRoofSquareId] then
+                                -- Both drain systems share a roof tile
+                                table.insert(queue, candidateDrain)
+                                break
+                            end
+                        end
+
+                    end
+                end
+            end
+        end
+    end
+
+    return relatedDrains
+end
+
+---@param sourceDrainPipeSquare IsoGridSquare
+---@return table<IsoObject>|nil drainPipes
+function serviceUtils:getAssociatedGutterDrains(sourceDrainPipeSquare)
+    local localDrainPipes = self:getLocalDrainPipes3D(sourceDrainPipeSquare, enums.defaultDrainPipeSearchRadius, enums.defaultDrainPipeSearchHeight)
+    if not localDrainPipes then
+        return nil
+    end
+
+    -- Filter round 1 - use simple checks to reduce the list of drain pipes to those most likely to be 'related':
+    -- 1. filter by connected status (assume non-connected gutters are 'closed' and not collecting water)
+    -- 2. filter by building type 'vanilla' vs 'custom' (assume custom only relates to custom and vanilla only relates to vanilla)
+    -- 3.A if vanilla:
+    --     * filter by shared building id (assume different buildings are not related)
+    --     * filter by shared max level (assume if same max level then using same roof tiles)
+    -- 3.B if custom:
+    --  NOTE: use more complex checks to reduce the list of drain pipes to those that are 'related'
+    --      * filter by shared pipes
+    --      * filter by shared roof tiles
+
+    -- Determine if square has a pre-built building or is a player-built structure
+    local squareBuilding = isoUtils:getAttachedBuilding(sourceDrainPipeSquare)
+    local maxLevel = utils:getModDataMaxLevel(sourceDrainPipeSquare)
+
+    -- Reduce the list of drain pipes to only those relevant to the building mode
+    -- Note: more involved filters are applied externally
+    local associatedDrainPipes = table.newarray()
+    for i=1, #localDrainPipes do
+        local drainPipe = localDrainPipes[i]
+
+        -- 1. Filter by connected status
+        -- NOTE: pass through atm
+        local isDrainConnected = true -- utils:getModDataIsGutterConnected(drainPipe)
+        if isDrainConnected then
+            -- 2. Filter by building type
+            local drainBuilding = isoUtils:getAttachedBuilding(drainPipe:getSquare())
+            if squareBuilding then
+                -- 3.A Vanilla building mode
+                -- Check if the drain pipe is attached to the same building
+                if drainBuilding and drainBuilding:getID() == squareBuilding:getID() then
+                    -- Check if drains on the same building are getting water from the same level
+                    if maxLevel then
+                        local drainPipeSquare = drainPipe:getSquare()
+                        local pipeMaxLevel = utils:getModDataMaxLevel(drainPipeSquare)
+                        if pipeMaxLevel then
+                            if pipeMaxLevel == maxLevel then
+                                -- Add the drain pipe to the list of associated pipes
+                                table_insert(associatedDrainPipes, drainPipe)
+                            end
+                        else
+                            -- If the drain pipe doesn't have a max level, go ahead an add it to the list of associated pipes
+                            -- Would rather over estimate than under estimate
+                            table_insert(associatedDrainPipes, drainPipe)
+                        end
+                    else
+                        -- If for some reason the maxLevel is nil, go ahead an add it to the list of associated pipes
+                        -- Would rather over estimate than under estimate
+                        table_insert(associatedDrainPipes, drainPipe)
+                    end
+                end
+            else
+                -- 3.B Custom building mode
+                -- Check if the drain is not attached to any building
+                if not drainBuilding then
+                    table_insert(associatedDrainPipes, drainPipe)
+                end
+            end
+        end
+    end
+
+    -- TODO 3.B flood fill for custom drains
+    if not squareBuilding then
+        local _, primaryDrainPipe, _, _ = utils:getSpriteCategoryMemberOnTile(sourceDrainPipeSquare, enums.pipeType.drain)
+        if primaryDrainPipe then
+            utils:modPrint("Custom building mode detected. Performing flood fill for associated gutter drains.")
+            return self:filterGutterDrainsByFloodFill(primaryDrainPipe, associatedDrainPipes)
+        end
+    end
+
+    return associatedDrainPipes
+end
+
+-- TODO pass in primaryPipeMap
+---@param sourceDrainPipeSquare IsoGridSquare
 ---@return integer drainCount
-function serviceUtils:getActualGutterDrainCount(square)
-    local drainPipes = self:getLocalDrainPipes3D(square, enums.defaultDrainPipeSearchRadius, enums.defaultDrainPipeSearchHeight)
+function serviceUtils:getAssociatedGutterDrainCount(sourceDrainPipeSquare)
+    local drainPipes = self:getAssociatedGutterDrains(sourceDrainPipeSquare)
     if not drainPipes then
         return 0
     end
@@ -401,7 +536,7 @@ function serviceUtils:calculateGutterSectionRainFactor(gutterTileCount)
 end
 
 ---@param square IsoGridSquare
----@return table|nil gutterSection
+---@return GutterSection|nil gutterSection
 function serviceUtils:calculateGutterSection(square)
     -- Notes:
     -- 1 tile is 1 meter squared
@@ -420,6 +555,7 @@ function serviceUtils:calculateGutterSection(square)
 
     -- Rain intensity is already factored into base game systems so we need to balance the generated rain factor to be useful but not trivial or too powerful
     -- Realistically a roof gutter system would produce nearly an entire rain barrel's worth of water (600l) in just a few hours when considering the area of the roof
+    ---@type GutterSection
     local gutterSection = {
         roofArea = 0,
         tileCount = 0,
@@ -462,7 +598,7 @@ function serviceUtils:calculateGutterSection(square)
 
     gutterSection.averageGutterCapacity = self:getAverageGutterCapacity()
     gutterSection.optimalDrainCount = self:getEstimatedGutterDrainCount(gutterSection.roofArea, gutterSection.averageGutterCapacity)
-    gutterSection.drainCount = self:getActualGutterDrainCount(square)
+    gutterSection.drainCount = self:getAssociatedGutterDrainCount(square)
     gutterSection.tileCount, gutterSection.overflowArea = self:calculateGutterSectionTileCount(gutterSection.roofArea, gutterSection.optimalDrainCount, gutterSection.drainCount, gutterSection.averageGutterCapacity)
     gutterSection.rainFactor = self:calculateGutterSectionRainFactor(gutterSection.tileCount)
 

--- a/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Trough.lua
+++ b/Contents/mods/FunctionalGutters/42/media/lua/shared/FG_Utils_Trough.lua
@@ -6,13 +6,56 @@ local troughUtils = {}
 
 local troughNorthFieldIndex = nil
 local localFeedingTroughDef = FeedingTroughDef
+local table_insert = table.insert
+
+local function parseFeedingTroughDef()
+    -- Iterate through FeedingTroughDef and create a map of trough sprites
+    local troughSprites = table.newarray()
+    local primaryTroughSprites = table.newarray()
+    local smallTroughSprites = table.newarray()
+    local northTroughSprites = table.newarray()
+
+    for _, troughDef in pairs(localFeedingTroughDef) do
+        local troughLength = #troughDef.spriteN -- NOTE: atm spriteN and spriteW are always the same length
+        for i=1, troughLength do
+            local spriteN = troughDef.spriteN[i]
+            local spriteW = troughDef.spriteW[i]
+
+            table_insert(troughSprites, spriteN)
+            table_insert(troughSprites, spriteW)
+
+            table_insert(northTroughSprites, spriteN)
+
+            if i == 1 then
+                -- The first sprite in the definition table is the primary trough sprite
+                table_insert(primaryTroughSprites, spriteN)
+                table_insert(primaryTroughSprites, spriteW)
+
+                if troughLength == 1 then
+                    -- Single tile troughs
+                    table_insert(smallTroughSprites, spriteN)
+                    table_insert(smallTroughSprites, spriteW)
+                end
+            end
+        end
+    end
+
+    -- Override base enum references with the parsed trough sprites
+    enums.troughSprites = troughSprites
+    enums.primaryTroughSprites = primaryTroughSprites
+    enums.smallTroughSprites = smallTroughSprites
+    enums.northTroughSprites = northTroughSprites
+
+    utils:modPrint("FeedingTroughDef parsed. Trough sprites: " .. tostring(#enums.troughSprites) .. ", Primary trough sprites: " .. tostring(#enums.primaryTroughSprites) .. ", Small trough sprites: " .. tostring(#enums.smallTroughSprites))
+end
 
 ---Checks sprite name against a list of known trough sprites
 ---@param spriteName any
 ---@return boolean
 function troughUtils:isTroughSprite(spriteName)
-    for i=1, #enums.troughSprites do
-        local troughSprite = enums.troughSprites[i]
+    local troughSprites = enums:getTroughSprites()
+    for i=1, #troughSprites do
+        local troughSprite = troughSprites[i]
         if spriteName == troughSprite then
             return true
         end
@@ -23,8 +66,9 @@ end
 ---@param spriteName any
 ---@return boolean
 function troughUtils:isSingleTileTroughFromSprite(spriteName)
-    for i=1, #enums.smallTroughSprites do
-        local troughSprite = enums.smallTroughSprites[i]
+    local smallTroughSprites = enums:getSmallTroughSprites()
+    for i=1, #smallTroughSprites do
+        local troughSprite =smallTroughSprites[i]
         if spriteName == troughSprite then
             return true
         end
@@ -57,6 +101,19 @@ function troughUtils:isTroughNorth(troughObject)
     return value
 end
 
+---@param troughSpriteName string
+---@return boolean
+function troughUtils:isTroughSpriteNorth(troughSpriteName)
+    local northTroughSprites = enums:getNorthTroughSprites()
+    for i=1, #northTroughSprites do
+        local northTroughSprite = northTroughSprites[i]
+        if troughSpriteName == northTroughSprite then
+            return true
+        end
+    end
+    return false
+end
+
 ---@param troughObject IsoFeedingTrough|IsoObject
 ---@return boolean
 function troughUtils:isSecondaryTrough(troughObject)
@@ -73,7 +130,8 @@ end
 ---@return boolean
 function troughUtils:isPrimaryTroughSprite(troughSpriteName)
     for _, def in pairs(localFeedingTroughDef) do
-		if def.sprite1 == troughSpriteName or def.spriteNorth1 == troughSpriteName then
+        -- The 1st sprite in the definition table is the primary trough sprite
+		if def.spriteN[1] == troughSpriteName or def.spriteW[1] == troughSpriteName then
 			return true
 		end
     end
@@ -81,22 +139,57 @@ function troughUtils:isPrimaryTroughSprite(troughSpriteName)
     return false
 end
 
+
 ---@param troughObject IsoFeedingTrough|IsoObject
 ---@return IsoFeedingTrough|IsoObject|nil primaryTrough
 function troughUtils:getPrimaryTrough(troughObject)
+    if self:isTroughObject(troughObject) then
+        -- If troughObject is already an IsoFeedingTrough, return its master trough
+        return troughObject:getMasterTrough()
+    end
+
+    -- Trough is still an IsoObject, so we need to find the primary trough based on its sprite name
     local troughSpriteName = troughObject:getSpriteName()
+    if self:isPrimaryTroughSprite(troughSpriteName) then
+        -- Provided troughObject is the primary trough
+        return troughObject
+    end
+
+    -- Trough is a 'secondary' object, so we need to check the sprite grid
+    local troughSprite = troughObject:getSprite()
+    local troughSpriteGrid = troughSprite:getSpriteGrid()
+    if not troughSpriteGrid then
+        utils:modPrint("Trough sprite grid not found for: "..tostring(troughSpriteName))
+        return nil
+    end
+
+    -- .getSpriteGridPosX(this.sprite);
+    --         int var9 = var5.getSpriteGridPosY(this.sprite);
+    --         this.setLinkedX(var1.getX() + var5.getWidth() - var8 - 1);
+    --         this.setLinkedY(var1.getY() + var5.getHeight() - var9 - 1);
 
     for _, def in pairs(localFeedingTroughDef) do
-        if def.sprite1 == troughSpriteName or def.spriteNorth1 == troughSpriteName then
+        -- local troughLength = #def.spriteN -- NOTE: atm spriteN and spriteW are always the same length
+        -- for i=1, troughLength do
+        --     local spriteN = def.spriteN[i]
+        --     local spriteW = def.spriteW[i]
+
+        --     if spriteN == troughSpriteName or spriteW == troughSpriteName then
+        --         -- Provided troughObject is the primary trough
+        --         return troughObject
+        --     end
+        -- end
+
+        if def.spriteN[1] == troughSpriteName or def.spriteW[1] == troughSpriteName then
             -- Provided troughObject is the primary trough
             return troughObject
         end
 
-        if def.sprite2 == troughSpriteName or def.spriteNorth2 == troughSpriteName then
-            local north = def.spriteNorth2 == troughSpriteName
+        if def.spriteN[2] == troughSpriteName or def.spriteW[2] == troughSpriteName then
+            local north = def.spriteN[2] == troughSpriteName
             local x, y, z = isoUtils:getSquare2PosReverse(troughObject:getSquare(), north)
             local primarySquare = getCell():getGridSquare(x, y, z)
-            local primarySpriteName = north and def.spriteNorth1 or def.sprite1
+            local primarySpriteName = north and def.spriteN[1] or def.spriteW[1]
             local primaryTrough = utils:getSpecificIsoObjectFromSquare(primarySquare, primarySpriteName)
             if not primaryTrough then
                 return nil
@@ -115,17 +208,20 @@ end
 function troughUtils:getSecondaryTrough(troughObject)
     local troughSpriteName = troughObject:getSpriteName()
 
+    -- TODO if IsoFeedingTroughs are automatically converted on build, we can simplify
+    -- However, we now have triple & quad tile troughs so secondary troughs need to be handled differently
+
     for _, def in pairs(localFeedingTroughDef) do
-        if def.sprite2 == troughSpriteName or def.spriteNorth2 == troughSpriteName then
+        if def.spriteN[2] == troughSpriteName or def.spriteW[2] == troughSpriteName then
             -- Provided troughObject is the secondary trough
             return troughObject
         end
 
-        if def.sprite1 == troughSpriteName or def.spriteNorth1 == troughSpriteName then
-            local north = def.spriteNorth1 == troughSpriteName
+        if def.spriteN[1] == troughSpriteName or def.spriteW[1] == troughSpriteName then
+            local north = def.spriteN[1] == troughSpriteName
             local x, y, z = isoUtils:getSquare2Pos(troughObject:getSquare(), north)
             local secondarySquare = getCell():getGridSquare(x, y, z)
-            local secondarySpriteName = north and def.spriteNorth2 or def.sprite2
+            local secondarySpriteName = north and def.spriteN[2] or def.spriteW[2]
             local secondaryTrough = utils:getSpecificIsoObjectFromSquare(secondarySquare, secondarySpriteName)
             if not secondaryTrough then
                 return nil
@@ -139,6 +235,7 @@ function troughUtils:getSecondaryTrough(troughObject)
     return nil
 end
 
+-- TODO REDO
 ---@param troughObject IsoFeedingTrough|IsoObject
 ---@return IsoFeedingTrough|IsoObject|nil otherTrough
 function troughUtils:getOtherTroughObject(troughObject)
@@ -155,4 +252,13 @@ function troughUtils:getOtherTroughObject(troughObject)
     return self:getPrimaryTrough(troughObject)
 end
 
+Events.OnInitWorld.Add(function()
+    parseFeedingTroughDef()
+end)
+
 return troughUtils
+
+-- TODO
+-- Troughs now how 2 objects on each tile - 
+-- 1 is the original IsoObject and the other is the converted IsoFeedingTrough
+-- Appears to be a bug in 42.10

--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ If true, prints debug messages to the console and adds an additional context men
 - Add gutter system ui panel
 - Add newspaper classified ad for in-game tutorial
 
+### 1.3
+- Much improved pipe & roof mapping
+    - Previously for pre-existing structures: all gutter systems on the same building were considered 'associated'
+    - Previously for player-built structures: all gutter systems in the vicinity were considered 'associated'
+    - Now: only gutter systems with connected pipes or overlapping roofs are 'associated'
+- Reduced the radius of the restriction zone when building a new drain near existing drains from 6 to 3 
+    - Originally was a stop-gap solution to prevent some unbalanced/unrealistic edge case setups
+    - Decreased now as the new mapping systems solves most of the avenues for abuse
+    - Might decrease or remove completely in future updates
+- Updates to match changes in vanilla animal trough definitions from 42.10
+
 ## Next Steps
 ### TODO Medium Priority 
 - Update README to better reflect 1.2 updates

--- a/workshop.txt
+++ b/workshop.txt
@@ -41,21 +41,13 @@ description=  [*]Enjoy the benefits of a highly-efficient rain collector system.
 description=[/olist]
 description=
 description=[h3]Pre-Existing Structures[/h3]
-
-description=Pre-existing structures already have roof gutters meaning you won't have to build your own. To tap into these roof gutters, you will either need to find a building with an existing drain pipe or build a new drain pipe. 
-
+description=Pre-existing structures already have roof gutters meaning you won't have to build your own. To tap into these roof gutters, you will either need to find a building with an existing drain pipe or build a new drain pipe.
 description=
-
 description=On its own a drain pipe will reach the next level above. Additional vertical pipes can be built on top of the drain pipe to access roofs on higher floor levels.
-
 description=
-
 description=[h3]Player-Built Structures[/h3]
-
-description=Unlike pre-existing structures, player-built structures will require horizontal gutter pipes to expand the size of the roof's area being covered by the drain pipe. Each gutter pipe can collect rain from up to 4 grid-squares from its attachment point in a line. A roof square will be considered valid if it has a floor, isn't covered by a roof, and isn't occupied by an item such as a rain collector. 
-
+description=Unlike pre-existing structures, player-built structures will require horizontal gutter pipes to expand the size of the roof's area being covered by the drain pipe. Each gutter pipe can collect rain from up to 4 grid-squares from its attachment point in a line. A roof square will be considered valid if it has a floor, isn't covered by a roof, and isn't occupied by an item such as a rain collector.
 description=
-
 description=Use the "View Pipes" and "View Roof" buttons in the gutter ui panel to help visualize the connected pipes and covered roof area.
 description=
 description=[h2]Mod Settings[/h2]


### PR DESCRIPTION
- Much improved pipe & roof mapping
    - Previously for pre-existing structures: all gutter systems on the same building were considered 'associated'
    - Previously for player-built structures: all gutter systems in the vicinity were considered 'associated'
    - Now: only gutter systems with connected pipes or overlapping roofs are 'associated'
- Reduced the radius of the restriction zone when building a new drain near existing drains from 6 to 3 
    - Originally was a stop-gap solution to prevent some unbalanced/unrealistic edge case setups
    - Decreased now as the new mapping systems solves most of the avenues for abuse
    - Might decrease or remove completely in future updates
- Updates to match changes in vanilla animal trough definitions from 42.10